### PR TITLE
command-executer: run command with --no-wait argument

### DIFF
--- a/samples/command_executer/src/command_parser.rs
+++ b/samples/command_executer/src/command_parser.rs
@@ -21,6 +21,7 @@ pub struct RunArgs {
     pub cid: u32,
     pub port: u32,
     pub command: String,
+    pub no_wait: bool,
 }
 
 impl RunArgs {
@@ -29,6 +30,7 @@ impl RunArgs {
             cid: parse_cid(args)?,
             port: parse_port(args)?,
             command: parse_command(args)?,
+            no_wait: parse_no_wait(args),
         })
     }
 }
@@ -60,7 +62,15 @@ pub struct CommandOutput {
 }
 
 impl CommandOutput {
-    pub fn new(output: Output) -> Result<Self, String> {
+    pub fn new(stdout: String, stderr: String, code: i32) -> Self {
+        CommandOutput {
+            stdout,
+            stderr,
+            rc: Some(code),
+        }
+    }
+
+    pub fn new_from(output: Output) -> Result<Self, String> {
         Ok(CommandOutput {
             stdout: String::from_utf8(output.stdout).map_err(|err| format!("{:?}", err))?,
             stderr: String::from_utf8(output.stderr).map_err(|err| format!("{:?}", err))?,
@@ -88,6 +98,14 @@ fn parse_command(args: &ArgMatches) -> Result<String, String> {
         .value_of("command")
         .ok_or("Could not find command argument")?;
     Ok(String::from(command))
+}
+
+fn parse_no_wait(args: &ArgMatches) -> bool {
+    if args.is_present("no-wait") {
+        true
+    } else {
+        false
+    }
 }
 
 fn parse_localfile(args: &ArgMatches) -> Result<String, String> {

--- a/samples/command_executer/src/utils.rs
+++ b/samples/command_executer/src/utils.rs
@@ -57,6 +57,12 @@ macro_rules! create_app {
                             .help("command")
                             .takes_value(true)
                             .required(true),
+                    )
+                    .arg(
+                        Arg::with_name("no-wait")
+                            .long("no-wait")
+                            .help("command-executer won't wait the command's result")
+                            .takes_value(false),
                     ),
             )
             .subcommand(


### PR DESCRIPTION
Add the --no-wait argument to the run command. It takes
no value. If it is not present, the behaviour remains the
same: the command is sent to the enclave, it is executed
inside the enclave and when the command is finished,
the output is sent back.

If --no-wait is present, the command is sent to the enclave,
it is executed inside the enclave and an return code is
sent back immediately. The return code is 0 if the process
was spawned successfully and 1 otherwise. If the user
wants to see the output later, he can redirect it to a
file.

Signed-off-by: Alexandra Pirvulescu <alexprv@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
