### PR TITLE
Enclave start confirmation for testing commands

### DIFF
--- a/eif_loader/src/lib.rs
+++ b/eif_loader/src/lib.rs
@@ -235,7 +235,7 @@ pub fn enclave_ready(cid: u32, port: u32) -> Result<(), EifLoaderError> {
     // Wait until the other end is closed
     let mut buf = [0u8; 1];
     recv(client_fd, &mut buf, MsgFlags::empty())
-    .map_err(|_err| EifLoaderError::VsockReceivingError)?;
+        .map_err(|_err| EifLoaderError::VsockReceivingError)?;
 
     Ok(())
 }

--- a/src/resource_manager.rs
+++ b/src/resource_manager.rs
@@ -188,7 +188,7 @@ impl EnclaveResourceManager {
         self.init_cpus()?;
         let enclave_cid = self.start()?;
         eif_loader::enclave_ready(VMADDR_CID_PARENT, ENCLAVE_READY_VSOCK_PORT)
-        .map_err(|err| format!("Waiting on enclave to boot failed with error {:?}", err))?;
+            .map_err(|err| format!("Waiting on enclave to boot failed with error {:?}", err))?;
         Ok((enclave_cid, self.slot_id))
     }
 

--- a/src/testing_commands.rs
+++ b/src/testing_commands.rs
@@ -8,6 +8,7 @@ use crate::resource_manager::ResourceAllocator;
 use crate::ExitGracefully;
 use crate::NitroCliResult;
 use crate::ResourceAllocatorDriver;
+use crate::{ENCLAVE_READY_VSOCK_PORT, VMADDR_CID_PARENT};
 use clap::{App, Arg, ArgMatches, SubCommand};
 use eif_loader;
 use log::debug;
@@ -225,6 +226,9 @@ pub fn send_eif(args: &ArgMatches) -> NitroCliResult<()> {
         crate::resource_manager::between_packets_delay(),
     )
     .map_err(|err| format!("Failed to send eif Image: {:?}", err))?;
+
+    eif_loader::enclave_ready(VMADDR_CID_PARENT, ENCLAVE_READY_VSOCK_PORT)
+        .map_err(|err| format!("Waiting on enclave to boot failed with error {:?}", err))?;
     Ok(())
 }
 


### PR DESCRIPTION
When the user runs the run-enclave command, the CLI
waits for the confirmation that the enclave has booted.
The same thing should happen when the user is trying
to start an enclave using the testing commands. This
commit fixes the problem by waiting for the confirmation
when the send-image command is executed.

Signed-off-by: Alexandra Pirvulescu <alexprv@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
