### PR TITLE
Fix /proc/cpuinfo parsing on AMD

### DIFF
--- a/src/cpu_info.rs
+++ b/src/cpu_info.rs
@@ -62,7 +62,10 @@ impl CpuInfos {
             // its core_id at 2*i+1
             if line.contains("processor") {
                 ids.push(CpuInfos::get_value(line)?);
-            } else if line.contains("apicid") && !line.contains("initial") {
+            } else if line.contains("apicid")
+                && !line.contains("initial")
+                && !line.contains("flags")
+            {
                 let id = CpuInfos::get_value(line)?;
                 ids.push(id >> 1);
             }


### PR DESCRIPTION
When parsing the /proc/cpuinfo file, we are only extracting
the lines that contain the word "apicid". This word can also
appear in the lines that describe the flags. Those lines are
now ignored.

Signed-off-by: Alexandra Pirvulescu <alexprv@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
