### PR TITLE
Test console multiple connect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,7 @@ pub fn enclave_console(enclave_cid: u64) -> NitroCliResult<()> {
             .map_err(|err| format!("Failed to connect to the enclave: {}", err))?
             + CID_TO_CONSOLE_PORT_OFFSET,
     )?;
+    println!("Successfully connected to the console.");
     console.read_to(io::stdout().by_ref())?;
 
     Ok(())


### PR DESCRIPTION
Add a test to check that you can reconnect to the
console after closing the previous connection.

Also add a message to let the user know when the
connection to the console has been successfully
established.

Signed-off-by: Alexandra Pirvulescu <alexprv@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
