### PR TITLE
Makefile: Fix docker build context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ driver-deps:
 	&& echo "Successfully installed the nitro_cli_resource_allocator deps"
 
 build-container: tools/Dockerfile1804
-	docker image build -t $(CONTAINER_TAG) -f tools/Dockerfile1804 $(OBJ_PATH)/ \
+	docker image build -t $(CONTAINER_TAG) -f tools/Dockerfile1804 tools/ \
 		> $(OBJ_PATH)/build_container_output.log
 
 .PHONY: build-setup


### PR DESCRIPTION
There is no point in sending the build artefacts as part of the docker build
context.

It is the other way around we generate the container to be able to run builds.

Signed-off-by: Alexandru Gheorghe <aggh@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
