### PR TITLE
vsock-prox.service: Fix detecting of the current region

### DIFF
--- a/vsock_proxy/service/vsock-proxy.service
+++ b/vsock_proxy/service/vsock-proxy.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=start, reload and stop vsock-proxy service
+Description=start and stop vsock-proxy service
 After=sysinit.target
 DefaultDependencies=no
 
@@ -8,9 +8,8 @@ Type=simple
 StandardOutput=none
 StandardError=none
 SyslogIdentifier=vsock-proxy
-Environment=REGION=$(/bin/bash -ce "echo $HOSTNAME | cut -d '.' -f 2")
-ExecStart=/bin/bash -ce "exec /usr/sbin/vsock-proxy 8000 kms.${REGION}.amazonaws.com 443 >> /var/log/vsock-proxy.log 2>&1"
-ExecReload=/bin/bash -ce "exec /usr/sbin/vsock-proxy 8000 kms.${REGION}.amazonaws.com 443 >> /var/log/vsock-proxy.log 2>&1"
+ExecStart=/bin/bash -ce "REGION=$(curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region) ; \
+			exec /usr/sbin/vsock-proxy 8000 kms.$${REGION}.amazonaws.com 443 --config /etc/vsock_proxy/config.yaml"
 Restart=always
 TimeoutSec=0
 


### PR DESCRIPTION
- Hostname does not return the name of the region the instance is running in.
- We don't have reliable mechanism to reload vsock-proxy so it is better to
  just remove this property of the service and let the user run stop/start
  if it wants to restart the service.

Signed-off-by: Alexandru Gheorghe <aggh@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
