### PR TITLE
Add rpmspec to build nitro_enclaves as a dkms driver

### DIFF
--- a/drivers/virt/amazon/nitro_enclaves/Makefile
+++ b/drivers/virt/amazon/nitro_enclaves/Makefile
@@ -20,7 +20,7 @@ obj-m += nitro_enclaves.o
 
 nitro_enclaves-y := ne_pci_dev.o ne_main.o
 
-ccflags-y += -Wall -I$(src)/../../../../include
+ccflags-y += -Wall -I$(src)/../../../../include -I$(src)/include/
 
 KERNEL_RELEASE := $(shell uname -r)
 
@@ -34,3 +34,4 @@ all:
 
 clean:
 	$(MAKE) -C $(KERNEL_BUILD_DIR) M=$(shell pwd) clean
+

--- a/drivers/virt/amazon/nitro_enclaves/dkms.conf
+++ b/drivers/virt/amazon/nitro_enclaves/dkms.conf
@@ -1,0 +1,6 @@
+PACKAGE_NAME="nitro_enclaves"
+PACKAGE_VERSION=1.0-0
+BUILT_MODULE_NAME[0]="nitro_enclaves"
+DEST_MODULE_LOCATION[0]="/extra/nitro_enclaves"
+AUTOINSTALL="yes"
+

--- a/drivers/virt/amazon/nitro_enclaves/nitro-enclaves-dkms.spec
+++ b/drivers/virt/amazon/nitro_enclaves/nitro-enclaves-dkms.spec
@@ -1,0 +1,39 @@
+%{?!module_name: %define module_name nitro-enclaves}
+%{?!version: %define version 1.0}
+Name:		%{module_name}
+Version:	%{version}
+Release:	1%{?dist}
+Summary:	Nitro enclaves kernel driver
+
+License:	GPL-2.0
+Source0:	%{module_name}-%{version}.tar.bz2
+BuildRequires:	%kernel_module_package_buildreqs
+
+%kernel_module_package default
+
+%description
+This package contains the Nitro Enclaves kernel driver
+meant for mananging enclaves lifecycle.
+
+%prep
+%setup -c %{name}
+set -- *
+mkdir source
+mv "$@" source/
+mkdir obj
+
+%build
+for flavor in %flavors_to_build; do
+	echo $flavor
+	rm -rf obj/$flavor
+	cp -r source obj/$flavor
+	make -C %{kernel_source $flavor} M=$PWD/obj/$flavor
+done
+
+%install
+export INSTALL_MOD_PATH=$RPM_BUILD_ROOT
+export INSTALL_MOD_DIR=extra/%{name}
+for flavor in %flavors_to_build ; do
+	make -C %{kernel_source $flavor} modules_install \
+		M=$PWD/obj/$flavor
+done


### PR DESCRIPTION
Template has been written by using template-dkms-redhat-kmod.
This is just a stop gap till the module gets merged in the upstream linux, till then it doesn't hurt to have a mechanism to build it as an rpm package.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
