### PR TITLE
Makefile: Propagate build errors for nitro-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ nitro-tests: $(BASE_PATH)/src/main.rs build-setup  build-container
 		-v "$$(readlink -f ${BASE_PATH})":/nitro_src \
 		-v "$$(readlink -f ${OBJ_PATH})":/nitro_build \
 		$(CONTAINER_TAG) bin/bash -c \
-			'source /root/.cargo/env && \
+			'source /root/.cargo/env && set -o pipefail && \
 			OPENSSL_STATIC=yes OPENSSL_DIR=/musl_openssl/ cargo test \
 				--release \
 				--no-run \
@@ -164,7 +164,8 @@ nitro-tests: $(BASE_PATH)/src/main.rs build-setup  build-container
 				--manifest-path=/nitro_src/Cargo.toml \
 				--target=x86_64-unknown-linux-musl \
 				--target-dir=/nitro_build/nitro_cli \
-				--message-format json | \
+				--message-format json \
+				| tee /nitro_build/nitro-tests-build.log | \
 				jq -r "select(.profile.test == true) | .filenames[]" \
 					 > /nitro_build/test_executables.txt && \
 			chmod -R 777 nitro_build '


### PR DESCRIPTION
Because the make nitro-tests is forwarding it's output to jq through a pipe
errors were eaten and not properly reported back, fix that by setting pipefail.

Additionally saved the unprocessed output to a log file to easy debug build
errors.

Signed-off-by: Alexandru Gheorghe <aggh@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
