### PR TITLE
cli: Return empty array when no enclaves are present.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,6 @@ fn main() {
             enclave_proc_connection_close(&replies);
         }
         ("describe-enclaves", _) => {
-            // TODO: Replicate output of old CLI when no enclaves are available.
             replies.extend(
                 enclave_proc_command_send_all::<EmptyArgs>(
                     &EnclaveProcessCommandType::Describe,
@@ -70,7 +69,12 @@ fn main() {
                 .ok_or_exit("Failed to broadcast describe command."),
             );
             info!("Sent command: Describe");
-            enclave_proc_fetch_output(&replies);
+
+            if replies.len() == 0 {
+                println!("[]");
+            } else {
+                enclave_proc_fetch_output(&replies);
+            }
             enclave_proc_connection_close(&replies);
         }
         ("build-enclave", Some(args)) => {


### PR DESCRIPTION
Ensure that the user receives an answer when no enclaves are present.
Not having an answer may lead to confusion, since we cannot tell if we
do not have enclaves or our call encountered a failure.

Signed-off-by: Lucian Perju <perjul@amazon.com>

*Issue #, if available:*
https://sim.amazon.com/issues/NPE-1472

*Description of changes:*
These changes remove the following question: all my enclaves are dead or the CLI does not return anything?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
