### PR TITLE
Makefile: Set nitro-cli as default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 #                            #
 ##############################
 
+.DEFAULT_GOAL := nitro-cli
 
 CARGO   = cargo
 CC      = gcc


### PR DESCRIPTION
Makefile usually defaults to the first target in the file, which is not what we
wanted

Signed-off-by: Alexandru Gheorghe <aggh@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
