### PR TITLE
ci: Fix generation of test eif

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -36,6 +36,7 @@ echo 1024 > /proc/sys/vm/nr_hugepages
 source build/install/etc/profile.d//nitro-cli-env.sh
 
 # Build EIFS for testing
+mkdir -p test_images
 nitro-cli build-enclave --docker-uri 667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample --output-file test_images/vsock-sample.eif
 
 

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -10,4 +10,4 @@ lsmod | grep -q nitro_enclaves || \
     sudo insmod ${NITRO_CLI_INSTALL_DIR}/lib/modules/extra/nitro_enclaves/nitro_enclaves.ko
 
 export PATH=${PATH}:${NITRO_CLI_INSTALL_DIR}/usr/sbin/
-export NITRO_CLI_BLOBS=${NITRO_CLI_INSTALL_DIR}/var/nitro_cli
+export NITRO_CLI_BLOBS=${NITRO_CLI_INSTALL_DIR}/opt/nitro_cli


### PR DESCRIPTION
The blobs necessary for generating an EIF are placed in opt not var, so fix the
script that sets the environment.

Signed-off-by: Alexandru Gheorghe <aggh@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
