### PR TITLE
cli: Added the CPU IDs in the JSON output of `describe-enclaves`

### DIFF
--- a/src/common/json_output.rs
+++ b/src/common/json_output.rs
@@ -21,6 +21,8 @@ pub struct EnclaveDescribeInfo {
     #[serde(rename = "NumberOfCPUs")]
     /// The number of CPUs used by the enclave.
     pub cpu_count: u64,
+    #[serde(rename = "CPU IDs")]
+    pub cpu_ids: Vec<u32>,
     #[serde(rename = "MemoryMiB")]
     /// The memory provided to the enclave (in MiB).
     pub memory_mib: u64,
@@ -38,6 +40,7 @@ impl EnclaveDescribeInfo {
         enclave_id: String,
         enclave_cid: u64,
         cpu_count: u64,
+        cpu_ids: Vec<u32>,
         memory_mib: u64,
         state: String,
         flags: String,
@@ -47,6 +50,7 @@ impl EnclaveDescribeInfo {
             process_id: std::process::id(),
             enclave_cid,
             cpu_count,
+            cpu_ids,
             memory_mib,
             state,
             flags,

--- a/src/enclave_proc/resource_manager.rs
+++ b/src/enclave_proc/resource_manager.rs
@@ -21,6 +21,8 @@ use crate::enclave_proc::connection::Connection;
 use crate::enclave_proc::connection::{safe_conn_eprintln, safe_conn_println};
 use crate::enclave_proc::utils::get_run_enclaves_info;
 
+type UnpackedHandle = (u64, u64, u64, Vec<u32>, u64, u16, EnclaveState);
+
 /// IOCTL code for `KVM_CREATE_VM`.
 pub const KVM_CREATE_VM: u64 = nix::request_code_none!(KVMIO, 0x01) as _;
 
@@ -596,14 +598,13 @@ impl EnclaveManager {
     /// Get the resources needed for describing an enclave.
     ///
     /// The enclave handle is locked during this operation.
-    pub fn get_description_resources(
-        &self,
-    ) -> NitroCliResult<(u64, u64, u64, u64, u16, EnclaveState)> {
+    pub fn get_description_resources(&self) -> NitroCliResult<UnpackedHandle> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| e.to_string())?;
         Ok((
             locked_handle.slot_uid,
             locked_handle.enclave_cid.unwrap(),
             locked_handle.cpu_ids.len() as u64,
+            locked_handle.cpu_ids.clone(),
             locked_handle.allocated_memory_mib,
             locked_handle.flags as u16,
             locked_handle.state.clone(),

--- a/src/enclave_proc/utils.rs
+++ b/src/enclave_proc/utils.rs
@@ -26,12 +26,13 @@ pub fn flags_to_string(flags: u16) -> String {
 pub fn get_enclave_describe_info(
     enclave_manager: &EnclaveManager,
 ) -> NitroCliResult<EnclaveDescribeInfo> {
-    let (slot_uid, enclave_cid, cpus_count, memory_mib, flags, state) =
+    let (slot_uid, enclave_cid, cpus_count, cpu_ids, memory_mib, flags, state) =
         enclave_manager.get_description_resources()?;
     let info = EnclaveDescribeInfo::new(
         generate_enclave_id(slot_uid)?,
         enclave_cid,
         cpus_count,
+        cpu_ids,
         memory_mib,
         state.to_string(),
         flags_to_string(flags),


### PR DESCRIPTION
Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>

*Description of changes: Added a field containing a list of allocated CPU IDs in the output of `describe-enclaves`*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
