### PR TITLE
container: update rust and cargo-audit version

### DIFF
--- a/tools/Dockerfile1804
+++ b/tools/Dockerfile1804
@@ -23,7 +23,7 @@ RUN unzip /openssl_src/${OPENSSL_VERSION}.zip -d /openssl_src
 RUN cd /openssl_src/openssl-${OPENSSL_VERSION} && CC=musl-gcc CFLAGS=-fPIC ./Configure --prefix=/musl_openssl --openssldir=/musl_openssl no-shared no-engine no-afalgeng linux-x86_64 -DOPENSSL_NO_SECURE_MEMORY && make && make install
 
 # Setup the right rust ver
-ENV RUST_VERSION=1.38.0
+ENV RUST_VERSION=1.41.1
 RUN  source $HOME/.cargo/env && \
      rustup toolchain install ${RUST_VERSION}-x86_64-unknown-linux-gnu
 RUN  source $HOME/.cargo/env && \
@@ -31,6 +31,6 @@ RUN  source $HOME/.cargo/env && \
 RUN  source $HOME/.cargo/env && \
     rustup target add --toolchain ${RUST_VERSION} x86_64-unknown-linux-musl
 RUN  source $HOME/.cargo/env && \
-	cargo install cargo-audit --version ^0.11
+	cargo install cargo-audit --version ^0.12
 RUN apt-get install -y jq
 RUN echo "Container build ready to go"


### PR DESCRIPTION
Use 1.41.1 as a minimum to be consistent with other build systems we
use.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Description of changes:*
Building the container with rust 1.38 failed due to updated dependencies for cargo-audit. Target 1.41.1 as a minimum, since we are using that in other places as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
