### PR TITLE
cli: add empty directory required by bindgen

### DIFF
--- a/src/bindings/.gitignore
+++ b/src/bindings/.gitignore
@@ -1,0 +1,3 @@
+# Empty directory needed by bindgen to generate Rust bindings
+*
+!.gitignore


### PR DESCRIPTION
Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>

*Description of changes: add empty directory required by bindgen*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
