### PR TITLE
cli_poweruser: introduce more randomness in fuzzer tests

### DIFF
--- a/cli_poweruser/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/cli_poweruser/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -4,32 +4,20 @@ extern crate libfuzzer_sys;
 extern crate nitro_cli_poweruser;
 extern crate num_traits;
 
+use std::fs;
+use std::mem;
+
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use std::fs;
-use std::fs::File;
 
 #[allow(unused_imports)]
 use nitro_cli_poweruser::cli_dev::{
-    CliDev,
-    NitroEnclavesCmdReply,
-    NitroEnclavesEnclaveStart,
-    NitroEnclavesGetSlot,
-    NitroEnclavesEnclaveStop,
-    NitroEnclavesSlotAlloc,
-    NitroEnclavesSlotFree,
-    NitroEnclavesSlotAddMem,
-    NitroEnclavesSlotAddVcpu,
-    NitroEnclavesSlotCount,
-    NitroEnclavesNextSlot,
-    NitroEnclavesSlotInfo,
-    NitroEnclavesSlotAddBulkVcpu,
-    NitroEnclavesDestroy,
+    CliDev, NitroEnclavesCmdReply, NitroEnclavesDestroy, NitroEnclavesEnclaveStart,
+    NitroEnclavesEnclaveStop, NitroEnclavesGetSlot, NitroEnclavesNextSlot,
+    NitroEnclavesSlotAddBulkVcpu, NitroEnclavesSlotAddMem, NitroEnclavesSlotAddVcpu,
+    NitroEnclavesSlotAlloc, NitroEnclavesSlotCount, NitroEnclavesSlotFree, NitroEnclavesSlotInfo,
 };
-use nitro_cli_poweruser::cpu_info::CpuInfos;
 use nitro_cli_poweruser::resource_allocator_driver::ResourceAllocatorDriver;
-use nitro_cli_poweruser::resource_manager::online_slot_cpus;
-use nitro_cli_poweruser::resource_manager::EnclaveResourceManager;
 
 #[derive(FromPrimitive)]
 enum NitroEnclavesCmdType {
@@ -47,395 +35,145 @@ enum NitroEnclavesCmdType {
     NitroEnclavesDestroy,
 }
 
+#[derive(FromPrimitive)]
+enum FuzzerTestType {
+    FuzzerTestValidCommands,
+    FuzzerTestValidCommandsInvalidArgs,
+    FuzzerTestInvalidCommands,
+}
+
 const EIF_PATH: &str = "command_executer.eif";
-
-fn enclave_start(memory_mib: u64) {
-    let eif_file = File::open(EIF_PATH)
-        .map_err(|err| format!("Failed to open to eif file: {:?}", err));
-
-    if let Ok(eif_file) = eif_file {
-        let enclave_cid: Option<u64> = Some(0);
-        let cpu_infos = CpuInfos::new();
-
-        if let Ok(cpu_infos) = cpu_infos {
-            let cpu_ids = cpu_infos.get_cpu_ids(2);
-
-            if let Ok(cpu_ids) = cpu_ids {
-                let resource_manager = EnclaveResourceManager::new(
-                    enclave_cid,
-                    memory_mib,
-                    cpu_ids,
-                    eif_file,
-                    true
-                )
-                .map_err(|err| format!("Could not create enclave: {:?}", err));
-
-                if let Ok(mut resource_manager) = resource_manager {
-                    let enclave_create_result = resource_manager.create_enclave();
-
-                    if let Ok(enclave_create_result) = enclave_create_result {
-                        let (_enclave_cid, _slot_id) = enclave_create_result;
-                        let crt_slot_uid: u64 = _slot_id;
-
-                        // Stop enclave
-                        let stop = NitroEnclavesEnclaveStop::new(_slot_id);
-                        let _ = stop.submit(&mut resource_manager.cli_dev);
-
-                        // Slot_free
-                        let slot_free = NitroEnclavesSlotFree::new(crt_slot_uid);
-                        let _ = slot_free.submit(&mut resource_manager.cli_dev);
-
-                        let resource_allocator_driver = ResourceAllocatorDriver::new();
-                        if let Ok(resource_allocator_driver) = resource_allocator_driver {
-                            let _ = online_slot_cpus(&resource_allocator_driver, crt_slot_uid);
-
-                            let _ = resource_allocator_driver.free(crt_slot_uid);
-                        }
-                    }
-                }
-            } else {
-                eprintln!("Could not add the requested number of cpus");
-            }
-        } else {
-            eprintln!("CpuInfos init failed");
-        }
-    }
-}
-
-fn enclave_get_slot(slot_id: u64) {
-    let cli_dev = CliDev::new();
-
-    if let Ok(mut cli_dev) = cli_dev {
-        let cmd = NitroEnclavesGetSlot::new(slot_id);
-        let _ = cmd.submit(&mut cli_dev);
-    }
-}
-
-fn enclave_stop(slot_id: u64) {
-    let cli_dev = CliDev::new();
-
-    if let Ok(mut cli_dev) = cli_dev {
-        let cmd = NitroEnclavesEnclaveStop::new(slot_id);
-        let _ = cmd.submit(&mut cli_dev);
-    }
-}
-
-fn enclave_slot_alloc() {
-    let cli_dev = CliDev::new();
-
-    if let Ok(mut cli_dev) = cli_dev {
-        let cmd = NitroEnclavesSlotAlloc::new();
-        let reply = cmd.submit(&mut cli_dev);
-
-        if let Ok(reply) = reply {
-            let crt_slot_uid: u64 = reply.slot_uid;
-
-            // Slot_free
-            let slot_free = NitroEnclavesSlotFree::new(crt_slot_uid);
-            let _ = slot_free.submit(&mut cli_dev);
-
-            let resource_allocator_driver = ResourceAllocatorDriver::new();
-
-            if let Ok(resource_allocator_driver) = resource_allocator_driver {
-                let _ = online_slot_cpus(&resource_allocator_driver, crt_slot_uid);
-
-                let _ = resource_allocator_driver.free(crt_slot_uid);
-            }
-        }
-    }
-}
-
-fn enclave_slot_free(slot_id: u64) {
-    let cli_dev = CliDev::new();
-
-    if let Ok(mut cli_dev) = cli_dev {
-        let cmd = NitroEnclavesSlotFree::new(slot_id);
-        let _ = cmd.submit(&mut cli_dev);
-    }
-}
-
-fn enclave_slot_add_mem() {
-    let eif_file = File::open(EIF_PATH)
-        .map_err(|err| format!("Failed to open to eif file: {:?}", err));
-
-    if let Ok(eif_file) = eif_file {
-        let enclave_cid: Option<u64> = Some(0);
-        let memory_mib: u64 = 32;
-        let cpu_infos = CpuInfos::new();
-
-        if let Ok(cpu_infos) = cpu_infos {
-            let cpu_ids = cpu_infos.get_cpu_ids(2);
-
-            if let Ok(cpu_ids) = cpu_ids {
-                let resource_manager = EnclaveResourceManager::new(
-                    enclave_cid,
-                    memory_mib,
-                    cpu_ids,
-                    eif_file,
-                    false,
-                )
-                .map_err(|err| format!("Could not create enclave: {:?}", err));
-
-                if let Ok(mut resource_manager) = resource_manager {
-                    // Only add memory, without vCPUs
-                    let crt_slot_uid: u64 = resource_manager.slot_id;
-                    let regions = resource_manager.resource_allocator.allocate();
-
-                    if let Ok(regions) = regions {
-                        for region in regions {
-                            let add_mem = NitroEnclavesSlotAddMem::new(resource_manager.slot_id, region.mem_gpa, region.mem_size);
-                            let _ = add_mem.submit(&mut resource_manager.cli_dev);
-                        }
-
-                        // Slot_free
-                        let slot_free = NitroEnclavesSlotFree::new(crt_slot_uid);
-                        let _ = slot_free.submit(&mut resource_manager.cli_dev);
-
-                        let resource_allocator_driver = ResourceAllocatorDriver::new();
-
-                        if let Ok(resource_allocator_driver) = resource_allocator_driver {
-                            let _ = online_slot_cpus(&resource_allocator_driver, crt_slot_uid);
-
-                            let _ = resource_allocator_driver.free(crt_slot_uid);
-                        }
-                    }
-                }
-            } else {
-                eprintln!("Could not add the requested number of cpus");
-            }
-        } else {
-            eprintln!("CpuInfos init failed");
-        }
-    }
-}
-
-fn enclave_slot_add_vcpu() {
-    let eif_file = File::open(EIF_PATH)
-        .map_err(|err| format!("Failed to open to eif file: {:?}", err));
-
-    if let Ok(eif_file) = eif_file {
-        let enclave_cid: Option<u64> = Some(0);
-        let memory_mib: u64 = 32;
-        let cpu_infos = CpuInfos::new();
-
-        if let Ok(cpu_infos) = cpu_infos {
-            let cpu_ids = cpu_infos.get_cpu_ids(2);
-
-            if let Ok(cpu_ids) = cpu_ids {
-                let resource_manager = EnclaveResourceManager::new(
-                    enclave_cid,
-                    memory_mib,
-                    cpu_ids,
-                    eif_file,
-                    false,
-                )
-                .map_err(|err| format!("Could not create enclave: {:?}", err));
-
-                if let Ok(mut resource_manager) = resource_manager {
-                    // Add both memory and vCPUs
-                    let regions = resource_manager.resource_allocator.allocate();
-
-                    if let Ok(regions) = regions {
-                        for region in regions {
-                            let add_mem = NitroEnclavesSlotAddMem::new(resource_manager.slot_id, region.mem_gpa, region.mem_size);
-                            let _ = add_mem.submit(&mut resource_manager.cli_dev);
-                        }
-
-                        let crt_slot_uid: u64 = resource_manager.slot_id;
-                        for cpu_id in &resource_manager.cpu_ids {
-                            let add_cpu = NitroEnclavesSlotAddVcpu::new(resource_manager.slot_id, *cpu_id);
-                            let _ = add_cpu.submit(&mut resource_manager.cli_dev);
-                        }
-
-                        // Slot_free
-                        let slot_free = NitroEnclavesSlotFree::new(crt_slot_uid);
-                        let _ = slot_free.submit(&mut resource_manager.cli_dev);
-
-                        let resource_allocator_driver = ResourceAllocatorDriver::new();
-
-                        if let Ok(resource_allocator_driver) = resource_allocator_driver {
-                            let _ = online_slot_cpus(&resource_allocator_driver, crt_slot_uid);
-
-                            let _ = resource_allocator_driver.free(crt_slot_uid);
-                        }
-                    }
-                }
-            } else {
-                eprintln!("Could not add the requested number of cpus");
-            }
-        } else {
-            eprintln!("CpuInfos init failed");
-        }
-    }
-}
-
-fn enclave_slot_count() {
-    let cli_dev = CliDev::new();
-
-    if let Ok(mut cli_dev) = cli_dev {
-        let slot_count = NitroEnclavesSlotCount::new();
-        let _ = slot_count.submit(&mut cli_dev);
-    }
-}
-
-fn enclave_next_slot(slot_id: u64) {
-    let cli_dev = CliDev::new();
-
-    if let Ok(mut cli_dev) = cli_dev {
-        let slot_info = NitroEnclavesNextSlot::new(slot_id);
-        let _ = slot_info.submit(&mut cli_dev);
-    }
-}
-
-fn enclave_slot_info() {
-    let cli_dev = CliDev::new();
-
-    if let Ok(mut cli_dev) = cli_dev {
-        let cmd = NitroEnclavesSlotAlloc::new();
-        let reply = cmd.submit(&mut cli_dev);
-
-        if let Ok(reply) = reply {
-            let crt_slot_uid: u64 = reply.slot_uid;
-
-            let info_cmd = NitroEnclavesSlotInfo::new(crt_slot_uid);
-            let _ = info_cmd.submit(&mut cli_dev);
-
-            // Slot_free
-            let slot_free = NitroEnclavesSlotFree::new(crt_slot_uid);
-            let _ = slot_free.submit(&mut cli_dev);
-
-            let resource_allocator_driver = ResourceAllocatorDriver::new();
-
-            if let Ok(resource_allocator_driver) = resource_allocator_driver {
-                let _ = online_slot_cpus(&resource_allocator_driver, crt_slot_uid);
-
-                let _ = resource_allocator_driver.free(crt_slot_uid);
-            }
-        }
-    }
-}
-
-fn enclave_slot_add_bulk_vcpu() {
-    let eif_file = File::open(EIF_PATH)
-        .map_err(|err| format!("Failed to open eif file: {:?}", err));
-
-    if let Ok(eif_file) = eif_file {
-        let enclave_cid: Option<u64> = Some(0);
-        let memory_mib: u64 = 32;
-        let cpu_ids: Vec<u32> = Vec::new();
-        // Do not add specific CPU ids, only request 2 vCPUs
-
-        let resource_manager = EnclaveResourceManager::new(
-            enclave_cid,
-            memory_mib,
-            cpu_ids,
-            eif_file,
-            false,
-        )
-        .map_err(|err| format!("Could not create enclave: {:?}", err));
-
-        if let Ok(mut resource_manager) = resource_manager {
-            // Add both memory and bulk vCPUs
-            let regions = resource_manager.resource_allocator.allocate();
-
-            if let Ok(regions) = regions {
-                for region in regions {
-                    let add_mem = NitroEnclavesSlotAddMem::new(resource_manager.slot_id, region.mem_gpa, region.mem_size);
-                    let _ = add_mem.submit(&mut resource_manager.cli_dev);
-                }
-
-                let crt_slot_uid: u64 = resource_manager.slot_id;
-                let add_bulk_cpu = NitroEnclavesSlotAddBulkVcpu::new(resource_manager.slot_id, 2);
-                let _ = add_bulk_cpu.submit(&mut resource_manager.cli_dev);
-
-                // Slot free
-                let slot_free = NitroEnclavesSlotFree::new(crt_slot_uid);
-                let _ = slot_free.submit(&mut resource_manager.cli_dev);
-
-                let resource_allocator_driver = ResourceAllocatorDriver::new();
-
-                if let Ok(resource_allocator_driver) = resource_allocator_driver {
-                    let _ = online_slot_cpus(&resource_allocator_driver, crt_slot_uid);
-
-                    let _ = resource_allocator_driver.free(crt_slot_uid);
-                }
-            }
-        }
-    }
-}
-
-fn enclave_destroy() {
-    let cli_dev = CliDev::new();
-
-    if let Ok(mut cli_dev) = cli_dev {
-        let shutdown_cmd = NitroEnclavesDestroy::new();
-        let _ = shutdown_cmd.submit(&mut cli_dev);
-    }
-}
+const MIN_PAYLOAD_LENGTH: usize = 23;
+const WAIT_PERIOD: u64 = 100;
 
 fn eif_exists() -> bool {
     fs::metadata(EIF_PATH).is_ok()
 }
 
+fn generate_and_submit_random_cmd(data: &[u8], cmd_type: u8) {
+    let cli_dev = CliDev::new();
+
+    if let Ok(mut cli_dev) = cli_dev {
+        let enable_res = cli_dev.enable();
+        if let Ok(enable_res) = enable_res {
+            if enable_res {
+                match FromPrimitive::from_u8(cmd_type) {
+                    Some(NitroEnclavesCmdType::NitroEnclavesEnclaveStart) => {
+                        let cmd_ptr: *const NitroEnclavesEnclaveStart =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesEnclaveStart = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesGetSlot) => {
+                        let cmd_ptr: *const NitroEnclavesGetSlot =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesGetSlot = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesEnclaveStop) => {
+                        let cmd_ptr: *const NitroEnclavesEnclaveStop =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesEnclaveStop = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesSlotAlloc) => {
+                        let cmd_ptr: *const NitroEnclavesSlotAlloc =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesSlotAlloc = unsafe { *cmd_ptr };
+                        let reply = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                        if let Ok(reply) = reply {
+                            let crt_slot_uid: u64 = reply.slot_uid;
+
+                            // Slot free
+                            let slot_free = NitroEnclavesSlotFree::new(crt_slot_uid);
+                            let _ = slot_free.submit(&mut cli_dev);
+                            std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+
+                            let resource_allocator_driver = ResourceAllocatorDriver::new();
+
+                            if let Ok(resource_allocator_driver) = resource_allocator_driver {
+                                let _ = resource_allocator_driver.free(crt_slot_uid);
+                            }
+                        }
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesSlotFree) => {
+                        let cmd_ptr: *const NitroEnclavesSlotFree =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesSlotFree = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesSlotAddMem) => {
+                        let cmd_ptr: *const NitroEnclavesSlotAddMem =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesSlotAddMem = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesSlotAddVcpu) => {
+                        let cmd_ptr: *const NitroEnclavesSlotAddVcpu =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesSlotAddVcpu = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesSlotCount) => {
+                        let cmd_ptr: *const NitroEnclavesSlotCount =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesSlotCount = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesNextSlot) => {
+                        let cmd_ptr: *const NitroEnclavesNextSlot =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesNextSlot = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesSlotInfo) => {
+                        let cmd_ptr: *const NitroEnclavesSlotInfo =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesSlotInfo = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesSlotAddBulkVcpu) => {
+                        let cmd_ptr: *const NitroEnclavesSlotAddBulkVcpu =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesSlotAddBulkVcpu = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    Some(NitroEnclavesCmdType::NitroEnclavesDestroy) => {
+                        let cmd_ptr: *const NitroEnclavesDestroy =
+                            unsafe { mem::transmute(data.as_ptr()) };
+                        let cmd: NitroEnclavesDestroy = unsafe { *cmd_ptr };
+                        let _ = cmd.submit(&mut cli_dev);
+                        std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
+                    }
+                    None => {
+                        // Invalid command; do nothing
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[allow(dead_code)]
 #[allow(unused_must_use)]
 fuzz_target!(|data: &[u8]| {
+    std::thread::sleep(std::time::Duration::from_millis(WAIT_PERIOD));
     if eif_exists() {
-        if data.len() >= 10 {
-            let cmd_type: u8 = data[0];
-            match FromPrimitive::from_u8(cmd_type) {
-                Some(NitroEnclavesCmdType::NitroEnclavesEnclaveStart) => {
-                    enclave_start(data[9] as u64);
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesGetSlot) => {
-                    let mut slot: [u8; 8] = Default::default();
-                    slot.copy_from_slice(&data[1..9]);
+        if data.len() >= MIN_PAYLOAD_LENGTH {
+            let cmd_type: u8 = data[1];
 
-                    enclave_get_slot(u64::from_le_bytes(slot));
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesEnclaveStop) => {
-                    let mut slot: [u8; 8] = Default::default();
-                    slot.copy_from_slice(&data[1..9]);
-
-                    enclave_stop(u64::from_le_bytes(slot));
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesSlotAlloc) => {
-                    enclave_slot_alloc();
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesSlotFree) => {
-                    let mut slot: [u8; 8] = Default::default();
-                    slot.copy_from_slice(&data[1..9]);
-
-                    enclave_slot_free(u64::from_le_bytes(slot));
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesSlotAddMem) => {
-                    enclave_slot_add_mem();
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesSlotAddVcpu) => {
-                    enclave_slot_add_vcpu();
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesSlotCount) => {
-                    enclave_slot_count();
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesNextSlot) => {
-                    let mut slot: [u8; 8] = Default::default();
-                    slot.copy_from_slice(&data[1..9]);
-
-                    enclave_next_slot(u64::from_le_bytes(slot));
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesSlotInfo) => {
-                    enclave_slot_info();
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesSlotAddBulkVcpu) => {
-                    enclave_slot_add_bulk_vcpu();
-                }
-                Some(NitroEnclavesCmdType::NitroEnclavesDestroy) => {
-                    enclave_destroy();
-                }
-                None => {
-                    // Invalid command; do nothing
-                }
-            }
+            generate_and_submit_random_cmd(data, cmd_type);
         }
     } else {
         eprintln!("EIF file not found in current directory. Get it by running `aws s3 cp s3://stronghold-device-fuzzing/command_executer.eif .` inside aws-nitro-enclaves-cli/cli_poweruser/");

--- a/cli_poweruser/src/resource_manager.rs
+++ b/cli_poweruser/src/resource_manager.rs
@@ -91,10 +91,12 @@ impl ResourceAllocator {
                 return Err("Could not allocate enclave memory".to_string());
             }
 
-            if let Ok(region) = self
-                .resource_allocator_driver
-                .alloc(self.slot_uid, chunk_size * MiB)
-            {
+            if let Ok(region) = self.resource_allocator_driver.alloc(
+                self.slot_uid,
+                chunk_size.checked_mul(MiB).ok_or_else(|| {
+                    "Error while allocating memory region (multiplication overflow)".to_string()
+                })?,
+            ) {
                 allocated += chunk_size;
                 self.mem_regions.push(region);
             } else {


### PR DESCRIPTION
Refactored the fuzzer code in order to submit completely
random payloads to the stronghold device. A random chunk of
bytes is copied verbatim into each device-specific command.

This commit also adds a check for multiplication overflow,
which occurred when trying to allocate a memory region with
a too large chunk size and which was observed while
running the fuzzer.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
