### PR TITLE
nitro_enclaves: Temporarily remove NUMA node check for memory

### DIFF
--- a/drivers/virt/nitro_enclaves/ne_misc_dev.c
+++ b/drivers/virt/nitro_enclaves/ne_misc_dev.c
@@ -785,17 +785,6 @@ static int ne_set_user_memory_region_ioctl(struct ne_enclave *ne_enclave,
 		}
 #endif
 
-		if (ne_enclave->numa_node !=
-		    page_to_nid(ne_mem_region->pages[i])) {
-			dev_err_ratelimited(ne_misc_dev.this_device,
-					    "Page isn't from NUMA node %d\n",
-					    ne_enclave->numa_node);
-
-			rc = -EINVAL;
-
-			goto unpin_pages;
-		}
-
 		/*
 		 * TODO: Update once handled non-contiguous memory regions
 		 * received from user space.


### PR DESCRIPTION
Remove the check for NUMA node aware memory regions till the
configuration for hugetlbfs in user space is NUMA aware.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
