### PR TITLE
nitro_enclaves: Add Dockerfile for NE driver static analysis setup

### DIFF
--- a/drivers/virt/nitro_enclaves/Dockerfile
+++ b/drivers/virt/nitro_enclaves/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:20.04
+
+RUN apt update
+RUN apt install -y build-essential gcc linux-headers-$(uname -r) make


### PR DESCRIPTION
Add Dockerfile to setup static analysis for the NE kernel driver.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
