### PR TITLE
nitro_enclaves: Update NE driver Dockerfile to use v5.4 linux headers

### DIFF
--- a/drivers/virt/nitro_enclaves/Dockerfile
+++ b/drivers/virt/nitro_enclaves/Dockerfile
@@ -1,4 +1,15 @@
 FROM ubuntu:20.04
 
-RUN apt update
-RUN apt install -y build-essential gcc linux-headers-$(uname -r) make
+RUN apt-get update
+RUN apt-get install -y build-essential gcc make wget
+
+ENV KERNEL_REPO="https://kernel.ubuntu.com/~kernel-ppa/mainline"
+ENV KERNEL_VER="v5.4.52"
+ENV KERNEL_ARCH="amd64"
+ENV KERNEL_HDR="linux-headers-5.4.52-050452_5.4.52-050452.202007160732_all.deb"
+ENV KERNEL_HDR_GENERIC="linux-headers-5.4.52-050452-generic_5.4.52-050452.202007160732_amd64.deb"
+
+RUN wget "$KERNEL_REPO"/"$KERNEL_VER"/"$KERNEL_ARCH"/"$KERNEL_HDR" \
+         "$KERNEL_REPO"/"$KERNEL_VER"/"$KERNEL_ARCH"/"$KERNEL_HDR_GENERIC"
+
+RUN apt-get install -y ./"$KERNEL_HDR" ./"$KERNEL_HDR_GENERIC"


### PR DESCRIPTION
Update the linux headers version from the Dockerfile used for the NE
kernel driver static analysis setup to not rely on the kernel version on
the host, but have a specific one.

Use the latest version of the LTS kernel v5.4.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
