### PR TITLE
cli: Fix failing unit test

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -76,6 +76,7 @@ make nitro_enclaves || test_failed
 make nitro-cli || test_failed
 make vsock-proxy || test_failed
 make install || test_failed
+rmmod nitro_cli_resource_allocator
 insmod drivers/nitro_cli_resource_allocator/nitro_cli_resource_allocator.ko || test_failed
 
 # Ensure the Nitro Enclaves driver is inserted at the beginning.

--- a/src/enclave_proc/connection_listener.rs
+++ b/src/enclave_proc/connection_listener.rs
@@ -117,7 +117,7 @@ impl ConnectionListener {
             .map_err(|e| format!("Failed to bind connection listener: {:?}", e))?;
         self.enable_credentials_passing(&listener);
         self.socket
-            .start_monitoring()
+            .start_monitoring(true)
             .map_err(|e| format!("Failed to start socket monitoring: {:?}", e))?;
         debug!(
             "Connection listener started on socket {:?}.",


### PR DESCRIPTION
`enclave_proc::socket::tests::test_start_monitoring` was sometimes
failing due to a race between the thread running the test and the
thread spawned socket removal listener thread. In case the socket
file inode was removed directory by the user, the listener thread
forces the whole CLI process to exit abruptly, thus closing the
test thread as well (and making it report the test as failure,
since it does not finish execution).

Introduced an additional parameter that tells whether the listener
thread should trigger an exit or not. Under common circumstances,
this should be True, however in the context of the unit test,
it is necessary to give the test thread the chance to finish
execution and report the test status (so the variable is set
to False).

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
