### PR TITLE
make: Add common compile flags for C

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,17 @@ OPT_DIR               ?= /opt
 
 CONTAINER_TAG = "nitro_cli:1.0"
 
+# Flags common to C
+C_FLAGS := -Wall -Wextra -Wconversion
+C_FLAGS += -Wno-sign-conversion -Werror -Wduplicated-cond
+C_FLAGS += -fno-omit-frame-pointer -funsigned-char -fno-common
+C_FLAGS += -Wlogical-op -Wrestrict -Wdouble-promotion
+C_FLAGS += -Wredundant-decls
+C_FLAGS += -Wformat=2 -Wnull-dereference
+C_FLAGS += -ffunction-sections -fdata-sections
+C_FLAGS += -fstack-protector-strong
+C_FLAGS += -Wno-error=deprecated-declarations
+
 ##############################
 #                            #
 #      Makefile rules        #
@@ -118,11 +129,11 @@ driver-clean: nitro_enclaves-clean nitro_cli_resource_allocator-clean
 
 .PHONY: nc-vsock
 nc-vsock: nc-vsock.c build-setup
-	$(CC) -o $(OBJ_PATH)/nc-vsock nc-vsock.c
+	$(CC) $(C_FLAGS) -o $(OBJ_PATH)/nc-vsock nc-vsock.c
 
 .PHONY: init
 init: init.c build-setup
-	$(CC) -o $(OBJ_PATH)/init $< -static -static-libgcc -flto
+	$(CC) $(C_FLAGS) -o $(OBJ_PATH)/init $< -static -static-libgcc -flto
 
 # See .build-container rule for explanation.
 .build-nitro-cli: $(shell find $(BASE_PATH)/src -name "*.rs")

--- a/init.c
+++ b/init.c
@@ -53,7 +53,7 @@ _Noreturn void die(const char *msg);
         } \
     } while (0)
 
-#define finit_module(fd, param_values, flags) syscall(__NR_finit_module, fd, param_values, flags)
+#define finit_module(fd, param_values, flags) (int)syscall(__NR_finit_module, fd, param_values, flags)
 #define DEFAULT_PATH_ENV "PATH=/sbin:/usr/sbin:/bin:/usr/bin"
 #define NSM_PATH "nsm.ko"
 #define TIMEOUT 20000 // millis
@@ -223,7 +223,7 @@ void init_cgroups() {
     }
     // Skip the first line.
     for (;;) {
-        char c = fgetc(f);
+        int c = fgetc(f);
         if (c == EOF || c == '\n') {
             break;
         }
@@ -374,14 +374,13 @@ void init_nsm_driver() {
 
     fd = open(NSM_PATH, O_RDONLY | O_CLOEXEC);
     die_on(fd < 0, "failed to open nsm fd");
-
     rc = finit_module(fd, "", 0);
     die_on(rc < 0, "failed to insert nsm driver");
 
     die_on(close(fd), "close nsm fd");
 }
 
-int main(int argc, char **argv) {
+int main() {
     // Block all signals in init. SIGCHLD will still cause wait() to return.
     sigset_t set;
     sigfillset(&set);

--- a/nc-vsock.c
+++ b/nc-vsock.c
@@ -35,7 +35,7 @@ static int parse_cid(const char *cid_str)
 	char *end = NULL;
 	long cid = strtol(cid_str, &end, 10);
 	if (cid_str != end && *end == '\0') {
-		return cid;
+		return (int)cid;
 	} else {
 		fprintf(stderr, "invalid cid: %s\n", cid_str);
 		return -1;
@@ -47,7 +47,7 @@ static int parse_port(const char *port_str)
 	char *end = NULL;
 	long port = strtol(port_str, &end, 10);
 	if (port_str != end && *end == '\0') {
-		return port;
+		return (int)port;
 	} else {
 		fprintf(stderr, "invalid port number: %s\n", port_str);
 		return -1;


### PR DESCRIPTION
GCC Flags are added for C compiled binaries in order to
validate that warnings and errors are not present
during build.

Signed-off-by: Alexandru Vasile <lexnv@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
