### PR TITLE
Run build-enclave inside container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,12 +188,17 @@ nitro-cli-native:
 	$(CP) \
 		$(BASE_PATH)/samples/command_executer/resources/Dockerfile.alpine \
 		$(OBJ_PATH)/command-executer/command_executer_docker_dir/Dockerfile
-	NITRO_CLI_BLOBS=$(BASE_PATH)/blobs \
-		$(OBJ_PATH)/nitro_cli/x86_64-unknown-linux-musl/release/nitro-cli \
-			build-enclave \
-			--docker-uri command_executer:eif \
-			--docker-dir $(OBJ_PATH)/command-executer/command_executer_docker_dir \
-			--output-file $(OBJ_PATH)/command-executer/command_executer.eif
+	$(DOCKER) run \
+		-v "$$(readlink -f ${BASE_PATH})":/nitro_src \
+		-v "$$(readlink -f ${OBJ_PATH})":/nitro_build \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		$(CONTAINER_TAG) bin/bash -c \
+			'NITRO_CLI_BLOBS=/nitro_src/blobs \
+				/nitro_build/nitro_cli/x86_64-unknown-linux-musl/release/nitro-cli \
+					build-enclave \
+					--docker-uri command_executer:eif \
+					--docker-dir /nitro_build/command-executer/command_executer_docker_dir \
+					--output-file /nitro_build/command-executer/command_executer.eif'
 	touch $@
 
 command-executer: build-setup build-container .build-command-executer-eif

--- a/tools/Dockerfile1804
+++ b/tools/Dockerfile1804
@@ -38,4 +38,23 @@ RUN  source $HOME/.cargo/env && \
 RUN  source $HOME/.cargo/env && \
 	cargo install cargo-audit --version ^0.12
 RUN apt-get install -y jq
+
+# Install docker for nitro-cli build-enclave runs
+RUN apt-get update && \
+    apt-get -y install apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg > /tmp/dkey; apt-key add /tmp/dkey && \
+    add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+        $(lsb_release -cs) \
+        stable" && \
+    apt-get update && \
+    apt-get -y install docker-ce
+
+# Setup the env for nitro-cli
+RUN mkdir -p /var/log/nitro_enclaves
+
 RUN echo "Container build ready to go"


### PR DESCRIPTION
Make sure the environment is correctly setup for nitro-cli runs by
running it inside the Docker container.

Signed-off-by: Bogdan Neacsu <bnneacsu@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
