### PR TITLE
cli: update SPEC file for integration tests RPM

### DIFF
--- a/run-nitro-cli-integration-tests
+++ b/run-nitro-cli-integration-tests
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Install required packages
+pip3 install -U pytest
+
+cp -r /usr/share/nitro_enclaves/test_images/ .
+
+echo "===== Running integration tests except for the installation test ====="
+python3 -m pytest /usr/share/nitro_enclaves/tests/integration/ --ignore /usr/share/nitro_enclaves/tests/integration/test_installation.py
+
+rm -rf test_images/

--- a/sources
+++ b/sources
@@ -1,1 +1,2 @@
-a8b26d40ceb69dc6f10ba1752e338a234654f36d  nitro-cli-dependencies.tar.gz
+4d39f54b910f04ef0001c21a81a5993a811fa077  nitro-cli-dependencies.tar.gz
+d7c12226daf2bfb2ef2792c5d5698681e7292a0b  sample-eifs.tar.gz

--- a/tools/nitro-cli-config.sh
+++ b/tools/nitro-cli-config.sh
@@ -40,6 +40,10 @@ THIS_USER="$(whoami)"
 # visibility normally requires a log-out / log-in or reboot.
 SHELL_RESET="0"
 
+# A flag used for skipping the shell reset - only used when setting
+# up the environment for installing the integration tests RPM.
+SKIP_SHELL_RESET="0"
+
 # Trap any exit condition, including all fatal errors.
 trap 'error_handler $? $LINENO' EXIT
 error_handler() {
@@ -466,7 +470,6 @@ while getopts ":hd:cbrim:p:t:" opt; do
         p)  # Configure the CPU pool.
             configure_cpu_pool "$OPTARG"
             ;;
-
         # TODO: Update to a more appropriate option letter. getopts does not
         # support long name options.
         # TODO: Have either -p or -t provided as a script option at a time,
@@ -474,6 +477,9 @@ while getopts ":hd:cbrim:p:t:" opt; do
         t)  # Configure the CPU pool given the CPU count.
             configure_cpu_pool_by_cpu_count "$OPTARG"
             ;;
+        s) # Skip shell reset at exit.
+	    SKIP_SHELL_RESET=1
+	    ;;
 
         \?) # Invalid option(s) provided.
             fail "Invalid argument(s) provided."
@@ -482,7 +488,7 @@ while getopts ":hd:cbrim:p:t:" opt; do
 done
 
 # Reset the shell after configuring the driver.
-if [ "$SHELL_RESET" -eq 1 ]; then
+if [ "$SHELL_RESET" -eq 1 ] && [ "$SKIP_SHELL_RESET" -eq 0 ]; then
     echo "Shell will be reset."
     sudo_run "exec su -l $THIS_USER"
 fi


### PR DESCRIPTION
Updated the SPEC file in order to build a secondary
RPM package, used only for running the integration
tests defined in `tests/integration/`. Added a
runscript for triggering the tests.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
