### PR TITLE
Default install driver-deps to 'yes'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,10 @@ all: build-setup init nc-vsock nitro-cli nitro-cli-poweruser vsock-proxy
 .PHONY: driver-deps
 driver-deps:
 	((cat /etc/os-release | grep -qni  "Ubuntu"  \
-		&& sudo apt-get install linux-headers-$$(uname -r)) || \
+		&& sudo apt-get install -y linux-headers-$$(uname -r)) || \
 	(cat /etc/os-release | grep -qni  "Amazon Linux\|CentOS\|RedHat" \
-		&& sudo yum install kernel-headers-$$(uname -r) \
-		&& sudo yum install kernel-devel-$$(uname -r)) || \
+		&& sudo yum install -y kernel-headers-$$(uname -r) \
+		&& sudo yum install -y kernel-devel-$$(uname -r)) || \
 	echo "Warning: kernel-header were not installed") \
 	&& echo "Successfully installed the nitro_cli_resource_allocator deps"
 


### PR DESCRIPTION
For automated builds, the interactive y/n
options when installing driver dependencies
breaks the build.

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
