### PR TITLE
Add nitro-cli tools dir to user $PATH

### DIFF
--- a/tools/env.sh
+++ b/tools/env.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,5 +11,5 @@ fi
 lsmod | grep -q nitro_enclaves || \
     sudo insmod ${NITRO_CLI_INSTALL_DIR}/lib/modules/extra/nitro_enclaves/nitro_enclaves.ko
 
-export PATH=${PATH}:${NITRO_CLI_INSTALL_DIR}/usr/sbin/
+export PATH=${PATH}:${NITRO_CLI_INSTALL_DIR}/usr/sbin/:${NITRO_CLI_TOOLS_DIR}
 export NITRO_CLI_BLOBS=${NITRO_CLI_INSTALL_DIR}/opt/nitro_cli


### PR DESCRIPTION
Avoid invoking the nitro-cli-config.sh script
from other tools with its absolute path.

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
