### PR TITLE
cli-poweruser: Extend the mask of the device enable register

### DIFF
--- a/cli_poweruser/src/cli_dev.rs
+++ b/cli_poweruser/src/cli_dev.rs
@@ -59,7 +59,10 @@ pub const NITRO_ENCLAVES_RPLY_PENDING: usize = 0x0c;
 pub const NITRO_ENCLAVES_SEND_DATA: usize = 0x010;
 // 240 Bytes) Buffer for reading a reply.
 pub const NITRO_ENCLAVES_RECV_DATA: usize = 0x100;
-const DEV_ENABLE_MASK: u8 = 0x1;
+// The device enable register can hold 3 states: disabled, disabling, enabled
+// that are represented on 2 bits. Mask the first 2 least significant bits
+// for determining the state of the device.
+const DEV_ENABLE_MASK: u8 = 0x3;
 const DEBUG_FLAG: u64 = 0x1;
 
 #[derive(Default, Debug, Copy, Clone, Deserialize)]


### PR DESCRIPTION
The device enable register can hold 3 states, that are
represented on 2 bits. While a device disable is issued
to the Nitro device (write 0x0 to device enable register),
the device will enter a disabling state.

The disabling state was not captured by the register's mask
that was previously (0x1 hex: 0001 binary), because the
disabling state is 0x2 hex: 0010 binary. This was leading
to reporting a disabling device as disabled.

Signed-off-by: Alexandru Vasile <lexnv@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
