### PR TITLE
cli-rpm: Update SPEC file

### DIFF
--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -57,12 +57,15 @@ make vsock-proxy-native
 make NITRO_CLI_INSTALL_DIR=%{buildroot} SBIN_DIR=%{_sbindir} UNIT_DIR=%{_unitdir} VAR_DIR=%{_var} install-tools
 
 mkdir -p %{buildroot}/%{_sbindir}
-mkdir -p %{buildroot}/%{_datadir}/nitro_enclaves/test_images/
 mkdir -p %{buildroot}/%{_datadir}/nitro_enclaves/tests/integration/
 
 install -D -m 0755 run-nitro-cli-integration-tests %{buildroot}/%{_sbindir}/run-nitro-cli-integration-tests
-cp ./eifs/* %{buildroot}/%{_datadir}/nitro_enclaves/test_images/
+install -D -m 0755 config/nitro-cli-config %{buildroot}/%{_sbindir}/nitro-cli-config
+
 cp -r tests/integration/* %{buildroot}%{_datadir}/nitro_enclaves/tests/integration/
+
+cp -r drivers/ %{buildroot}%{_datadir}/nitro_enclaves/
+cp -r include/ %{buildroot}%{_datadir}/nitro_enclaves/
 
 
 %post
@@ -86,6 +89,7 @@ systemctl --system daemon-reload
 %defattr(0755,root,root,0755)
 
 %{_sbindir}/run-nitro-cli-integration-tests
+%{_sbindir}/nitro-cli-config
 %{_datadir}/nitro_enclaves/*
 
 

--- a/config/nitro-cli-config
+++ b/config/nitro-cli-config
@@ -704,7 +704,7 @@ cpu_count_request=
 cpu_id_request=
 memory_request=
 
-while getopts ":hd:cbrim:p:t:v" opt; do
+while getopts ":hd:cbrim:p:t:vs" opt; do
     case ${opt} in
         h)  # Help was requested.
             print_usage

--- a/run-nitro-cli-integration-tests
+++ b/run-nitro-cli-integration-tests
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 # Install required packages
-pip3 install -U pytest
+echo "===== Installing required packages ====="
+sudo pip3 install -U pytest > /dev/null 2>&1
+sudo yum install -y kernel-headers-$(uname -r) kernel-devel-$(uname -r) > /dev/null 2>&1
 
-cp -r /usr/share/nitro_enclaves/test_images/ .
+# Configure enclaves environment
+echo "===== Configuring enclaves environment ====="
+PREV_DIR=$(pwd) && cd /usr/share/nitro_enclaves/drivers/virt/nitro_enclaves && sudo make > /dev/null 2>&1 && cd $PREV_DIR
+nitro-cli-config -s -d /usr/share/nitro_enclaves -i
 
+nitro-cli-config -m 2048 -t 2
+
+# Run integration tests
 echo "===== Running integration tests except for the installation test ====="
 python3 -m pytest /usr/share/nitro_enclaves/tests/integration/ --ignore /usr/share/nitro_enclaves/tests/integration/test_installation.py
-
-rm -rf test_images/

--- a/sources
+++ b/sources
@@ -1,2 +1,1 @@
-4d39f54b910f04ef0001c21a81a5993a811fa077  nitro-cli-dependencies.tar.gz
-d7c12226daf2bfb2ef2792c5d5698681e7292a0b  sample-eifs.tar.gz
+4d39f54b910f04ef0001c21a81a5993a811fa077 nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
Updated the SPEC file in order to generate a version of
the integration tests RPM which does not need sample
EIF files provided in the repository anymore.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
