### PR TITLE
Fixup StrongholdPCI timing test

### DIFF
--- a/cli_poweruser/src/cli_dev.rs
+++ b/cli_poweruser/src/cli_dev.rs
@@ -413,14 +413,14 @@ impl CliDev {
         command: C,
     ) -> NitroCliResult<NitroEnclavesCmdReply> {
         debug!("submit: {:?}", command);
-        let past_reply = self.read_u32(NITRO_ENCLAVES_RPLY_PENDING)?;
+        let past_reply = self.read_u32(NITRO_ENCLAVES_RPLY_PENDING)? & 0xFFFF;
 
         self.submit_command(cmd_type, command)?;
 
         let mut num_trys = 20000;
         let mut warn_trys = 200;
         let err_prefix = sanitize_command(cmd_type);
-        while past_reply == self.read_u32(NITRO_ENCLAVES_RPLY_PENDING)? && num_trys > 0 {
+        while past_reply == (self.read_u32(NITRO_ENCLAVES_RPLY_PENDING)? & 0xFFFF) && num_trys > 0 {
             sleep(time::Duration::from_millis(10));
             num_trys -= 1;
             warn_trys -= 1;


### PR DESCRIPTION
The problem that happens here is that we changed the REPLY_PENDING_REGISTER in
two parts the first 16 bits holds the number of replies received and the last 16
bits is the number of rescans sent, in case something goes wrong with an enclave
running.

So, what it is going one here is that we launch an enclave that does have a
valid image, so that triggers a rescan which increments the counter, while a the
same time the parent instance is trying to send a new stronghold command, so it
confuses the rescan as a reply for the command that it just sent.

Signed-off-by: Alexandru Gheorghe <aggh@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
