### PR TITLE
cli: Print info message to stderr

### DIFF
--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -241,7 +241,7 @@ fn parse_enclave_cid(args: &ArgMatches) -> NitroCliResult<Option<u64>> {
         // Note: 0 is used as a placeholder to auto-generate a CID.
         // <http://man7.org/linux/man-pages/man7/vsock.7.html>
         if enclave_cid == 0 {
-            println!("The enclave CID will be auto-generated as the provided CID is 0");
+            eprintln!("The enclave CID will be auto-generated as the provided CID is 0");
         }
 
         if enclave_cid > 0 && enclave_cid <= VMADDR_CID_HOST as u64 {


### PR DESCRIPTION
Any message that is not part of the output
json should be printed to stderr.

Signed-off-by: Alexandra Pirvulescu <alexprv@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
