### PR TITLE
nitro-cli: Adapt timeout in the enclave boot heartbeat logic

### DIFF
--- a/cli_poweruser/src/testing_commands.rs
+++ b/cli_poweruser/src/testing_commands.rs
@@ -13,7 +13,7 @@ use crate::ENCLAVE_READY_VSOCK_PORT;
 use crate::VMADDR_CID_PARENT;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
-use eif_loader;
+use eif_loader::{enclave_ready, TIMEOUT_MINUTE_MS};
 use log::debug;
 use nix::sys::socket::SockAddr;
 use num_traits::FromPrimitive;
@@ -274,7 +274,8 @@ pub fn execute_command(args: &ArgMatches) -> NitroCliResult<()> {
 
     match cmd_id {
         NitroEnclavesCmdType::NitroEnclavesEnclaveStart => {
-            eif_loader::enclave_ready(listener.unwrap()).map_err(|err| {
+            // Use the default 1 minute timeout as there is no info about the enclave memory size.
+            enclave_ready(listener.unwrap(), TIMEOUT_MINUTE_MS).map_err(|err| {
                 format!(
                     "Failed to receive 'ready' signal from the enclave: {:?}",
                     err

--- a/eif_loader/src/lib.rs
+++ b/eif_loader/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![deny(warnings)]
 
+use libc::c_int;
 use nix::poll::poll;
 use nix::poll::{PollFd, PollFlags};
 use std::io::Read;
@@ -9,7 +10,12 @@ use std::io::Write;
 use std::os::unix::io::AsRawFd;
 use vsock::VsockListener;
 
-const ACCEPT_TIMEOUT: i32 = 60000; // millis
+/// Timeout of 1 second in milliseconds
+pub const TIMEOUT_SECOND_MS: i32 = 1000;
+
+/// Timeout of 1 minute in milliseconds
+pub const TIMEOUT_MINUTE_MS: i32 = 60 * TIMEOUT_SECOND_MS;
+
 const HEART_BEAT: u8 = 0xB7;
 
 #[derive(Debug, PartialEq)]
@@ -22,9 +28,12 @@ pub enum EifLoaderError {
     VsockTimeoutError,
 }
 
-pub fn enclave_ready(listener: VsockListener) -> Result<(), EifLoaderError> {
+pub fn enclave_ready(
+    listener: VsockListener,
+    poll_timeout_ms: c_int,
+) -> Result<(), EifLoaderError> {
     let mut poll_fds = [PollFd::new(listener.as_raw_fd(), PollFlags::POLLIN)];
-    let result = poll(&mut poll_fds, ACCEPT_TIMEOUT);
+    let result = poll(&mut poll_fds, poll_timeout_ms);
     if result == Ok(0) {
         return Err(EifLoaderError::VsockTimeoutError);
     } else if result != Ok(1) {


### PR DESCRIPTION
It happened during validation that sometimes the default one minute
timeout would not be enough for waiting for a connection from the
enclave during the enclave boot check logic. Thus, it should be tweaked
considering the enclave memory size.

For now, adapt the timeout to be one minute per 100 GiB of enclave
memory (e.g. an enclave with 300 GiB of memory will have a timeout set
to 3 minutes).

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
