### PR TITLE
nitro_enclaves: Fixup type of the poll result assigned value

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a collection of tools and commands used for managing th
   2. Install gcc, make, git, llvm-dev, libclang-dev, clang.
 
 ### Driver information
-  The Nitro Enclaves kernel driver is currently at version 0.9. Out-of-tree driver build is supported.
+  The Nitro Enclaves kernel driver is currently at version 0.10. Out-of-tree driver build is supported.
 
 ### How to install (Git):
   1. Clone the repository.

--- a/drivers/virt/nitro_enclaves/ne_misc_dev.c
+++ b/drivers/virt/nitro_enclaves/ne_misc_dev.c
@@ -1586,7 +1586,7 @@ static __poll_t ne_enclave_poll(struct file *file, poll_table *wait)
 	if (!ne_enclave->has_event)
 		return mask;
 
-	mask = POLLHUP;
+	mask = EPOLLHUP;
 
 	return mask;
 }

--- a/drivers/virt/nitro_enclaves/ne_misc_dev.h
+++ b/drivers/virt/nitro_enclaves/ne_misc_dev.h
@@ -19,10 +19,11 @@
 
 /*
  * The type '__poll_t' is not available in kernels older than 4.16.0
- * so for these we define it here.
+ * so for these we define it here. Also define EPOLLHUP.
  */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
-#define __poll_t unsigned int
+#define __poll_t	unsigned int
+#define EPOLLHUP	(__force __poll_t)0x00000010
 #endif
 
 /**


### PR DESCRIPTION
Update the assigned value of the poll result to be EPOLLHUP instead of
POLLHUP to match the __poll_t type.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>
Reported-by: kernel test robot <lkp@intel.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
