### PR TITLE
spec: Change license string from "Apache-2.0" to "Apache 2.0"

### DIFF
--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -13,9 +13,9 @@
 Summary:    AWS Nitro Enclaves tools for managing enclaves
 Name:       aws-nitro-enclaves-cli
 Version:    1.0
-Release:    2%{?dist}
+Release:    3%{?dist}
 
-License:    Apache-2.0
+License:    Apache 2.0
 
 BuildArch: x86_64
 
@@ -159,6 +159,9 @@ rm -rf %{ne_log_dir}
 %{ne_include_dir}/*
 
 %changelog
+* Mon Oct 19 2020 Gabriel Bercaru <dhr@amazon.com> - 1.0.3
+- Changed license to Apache 2.0
+
 * Sat Oct 17 2020 Dan Horobeanu <dhr@amazon.com> - 1.0-1
 - Updated license to Apache-2.0
 - General cleanup and resync with `make install` output


### PR DESCRIPTION
Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>

Updated license string to 'Apache 2.0' and updated the package release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
