### PR TITLE
packaging: fixed systemd service files for AL2

### DIFF
--- a/bootstrap/nitro-enclaves-allocator.service
+++ b/bootstrap/nitro-enclaves-allocator.service
@@ -1,8 +1,7 @@
 [Unit]
-Description=reserve resources (memory and CPUs) for launching enclaves
+Description=Nitro Enclaves Resource Allocator
 DefaultDependencies=no
-Wants=dev-nitro_enclaves.device
-After=sysinit.target dev-nitro_enclaves.device
+After=sysinit.target
 
 [Service]
 Type=oneshot
@@ -10,8 +9,7 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=nitro-enclaves-allocator
 ExecStart=/usr/bin/nitro-enclaves-allocator
-RemainAfterExit=false
-TimeoutSec=0
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/vsock_proxy/service/nitro-enclaves-vsock-proxy.service
+++ b/vsock_proxy/service/nitro-enclaves-vsock-proxy.service
@@ -1,6 +1,6 @@
 [Unit]
-Description=start and stop vsock-proxy service
-After=network.target
+Description=Nitro Enclaves vsock Proxy
+After=network-online.target
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION
*Description of changes:*

Fixed a few problems in the systemd service files for AL2 packaging:
- allocator: removed dependency on dev-nitro_enclaves, since there is
  no .device unit for /dev/nitro_enclaves; the device would already
  be loaded at sysinit.target anyway;
- allocator: set RemainedAfterExit=true, since we want the allocation
  to be considered successful after the first run;
- allocator: removed timeout, since it's ignored for oneshot services;
- vsock-proxy: fixed After= requirement to network-online.target.

Signed-off-by: Dan Horobeanu <dhr@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
