### PR TITLE
cli: Improve file operation error messages

### DIFF
--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -39,6 +39,7 @@ impl RunEnclavesArgs {
                     &format!("Failed to open config file: {:?}", err),
                     NitroCliErrorEnum::FileOperationFailure
                 )
+                .add_info(vec![config_file, "Open"])
             })?;
 
             let json: RunEnclavesArgs = serde_json::from_reader(file).map_err(|err| {

--- a/src/common/document_errors.rs
+++ b/src/common/document_errors.rs
@@ -153,6 +153,16 @@ pub fn get_detailed_info(error_code_str: String, additional_info: &[String]) -> 
         }
         "E19" => {
             ret.push_str("File operation failure. Such error appears when the system fails to perform the requested file operations, such as opening the EIF file when launching an enclave, or seeking to a specific offset in the EIF file, or writing to the log file.");
+            if additional_info.len() >= 2 {
+                ret.push_str(
+                    format!(
+                        "\nFile: '{}', failing operation: '{}'.",
+                        additional_info.get(0).unwrap_or(&info_placeholder),
+                        additional_info.get(1).unwrap_or(&info_placeholder),
+                    )
+                    .as_str(),
+                );
+            }
         }
         "E20" => {
             ret.push_str(

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -179,6 +179,12 @@ fn open_log_file(file_path: &Path) -> NitroCliResult<File> {
                 &format!("Failed to open log file: {:?}", e),
                 NitroCliErrorEnum::FileOperationFailure
             )
+            .add_info(vec![
+                file_path
+                    .to_str()
+                    .unwrap_or("Invalid unicode log file name"),
+                "Open",
+            ])
         })?;
 
     let log_file_uid = Uid::from_raw(
@@ -188,6 +194,12 @@ fn open_log_file(file_path: &Path) -> NitroCliResult<File> {
                     &format!("Failed to get log file metadata: {:?}", e),
                     NitroCliErrorEnum::FileOperationFailure
                 )
+                .add_info(vec![
+                    file_path
+                        .to_str()
+                        .unwrap_or("Invalid unicode log file name"),
+                    "Get metadata",
+                ])
             })?
             .uid(),
     );

--- a/src/enclave_proc/commands.rs
+++ b/src/enclave_proc/commands.rs
@@ -29,6 +29,7 @@ pub fn run_enclaves(
             &format!("Failed to open the EIF file: {:?}", e),
             NitroCliErrorEnum::FileOperationFailure
         )
+        .add_info(vec![&args.eif_path, "Open"])
     })?;
 
     let cpu_ids = CpuInfo::new()

--- a/src/enclave_proc/resource_manager.rs
+++ b/src/enclave_proc/resource_manager.rs
@@ -62,6 +62,9 @@ const NE_DEFAULT_MEMORY_REGION: u64 = 0;
 /// Magic number for Nitro Enclave IOCTL codes.
 const NE_MAGIC: u64 = 0xAE;
 
+/// Path corresponding to the Nitro Enclaves device file.
+const NE_DEV_FILEPATH: &str = "/dev/nitro_enclaves";
+
 /// IOCTL code for `NE_CREATE_VM`.
 pub const NE_CREATE_VM: u64 = nix::request_code_read!(NE_MAGIC, 0x20, size_of::<u64>()) as _;
 
@@ -498,12 +501,13 @@ impl EnclaveHandle {
         let dev_file = OpenOptions::new()
             .read(true)
             .write(true)
-            .open("/dev/nitro_enclaves")
+            .open(NE_DEV_FILEPATH)
             .map_err(|e| {
                 new_nitro_cli_failure!(
                     &format!("Failed to open device file: {:?}", e),
                     NitroCliErrorEnum::FileOperationFailure
                 )
+                .add_info(vec![NE_DEV_FILEPATH, "Open"])
             })?;
 
         let mut slot_uid: u64 = 0;

--- a/src/enclave_proc/socket.rs
+++ b/src/enclave_proc/socket.rs
@@ -121,6 +121,12 @@ impl EnclaveProcSock {
                     ),
                     NitroCliErrorEnum::FileOperationFailure
                 )
+                .add_info(vec![
+                    self.socket_path
+                        .to_str()
+                        .unwrap_or("Invalid unicode socket file name"),
+                    "Remove",
+                ])
             })?;
         }
 

--- a/src/enclave_proc/utils.rs
+++ b/src/enclave_proc/utils.rs
@@ -79,6 +79,7 @@ pub fn generate_enclave_id(slot_id: u64) -> NitroCliResult<String> {
                 &format!("Failed to open file: {:?}", e),
                 NitroCliErrorEnum::FileOperationFailure
             )
+            .add_info(vec![file_path, "Open"])
         })?;
         let mut contents = String::new();
         file.read_to_string(&mut contents).map_err(|e| {
@@ -86,6 +87,7 @@ pub fn generate_enclave_id(slot_id: u64) -> NitroCliResult<String> {
                 &format!("Failed to read from file: {:?}", e),
                 NitroCliErrorEnum::FileOperationFailure
             )
+            .add_info(vec![file_path, "Read"])
         })?;
         contents.retain(|c| !c.is_whitespace());
         return Ok(format!("{}-enc{:x}", contents, slot_id));

--- a/src/enclave_proc_comm.rs
+++ b/src/enclave_proc_comm.rs
@@ -107,6 +107,7 @@ pub fn enclave_proc_connect_to_all() -> NitroCliResult<Vec<UnixStream>> {
                                     &format!("Failed to delete socket: {:?}", e),
                                     NitroCliErrorEnum::FileOperationFailure
                                 )
+                                .add_info(vec![path_str, "Remove"])
                             });
                         }
                     }

--- a/tests/test_dev_driver.rs
+++ b/tests/test_dev_driver.rs
@@ -62,6 +62,7 @@ impl NitroEnclavesDeviceDriver {
                     .add_subaction(format!("Could not open {}: {}", NE_DEVICE_PATH, e))
                     .set_error_code(NitroCliErrorEnum::FileOperationFailure)
                     .set_file_and_line(file!(), line!())
+                    .add_info(vec![NE_DEVICE_PATH, "Open"])
             })?,
         })
     }


### PR DESCRIPTION
Improves the error messsages displayed when a file
operation fails, by outputting the file name as well
as the attempted operation.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
