### PR TITLE
cli: Ensure enclave is started with enough memory

### DIFF
--- a/src/common/document_errors.rs
+++ b/src/common/document_errors.rs
@@ -202,14 +202,13 @@ pub fn get_detailed_info(error_code_str: String, additional_info: &[String]) -> 
             ret.push_str("No such hugepage flag error. Such error appears when the enclave process attempts to use an invalid hugepage size (size other than the known hugepage sizes) for initializing the enclave memory.");
         }
         "E26" => {
-            if additional_info.len() >= 4 {
+            if additional_info.len() >= 3 {
                 ret.push_str(
                     format!(
-                        "Insufficient memory requested. User provided `{}` is {} MB, but `{}` is larger ({} MB)",
+                        "Insufficient memory requested. User provided `{}` is {} MB, but based on the EIF file size, the minimum memory should be {} MB",
                         additional_info.get(0).unwrap_or(&info_placeholder),
                         additional_info.get(1).unwrap_or(&info_placeholder),
-                        additional_info.get(2).unwrap_or(&info_placeholder),
-                        additional_info.get(3).unwrap_or(&info_placeholder)
+                        additional_info.get(2).unwrap_or(&info_placeholder)
                     ).as_str(),
                 );
             } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -229,3 +229,17 @@ fn vsock_set_connect_timeout(fd: RawFd, millis: i64) -> NitroCliResult<()> {
         )),
     }
 }
+
+/// Computes the ceil of `lhs / rhs`. Used for reporting the lower
+/// limit of enclave memory based on the EIF file size.
+pub fn ceil_div(lhs: u64, rhs: u64) -> u64 {
+    if rhs == 0 {
+        return std::u64::MAX;
+    }
+
+    lhs / rhs
+        + match lhs % rhs {
+            0 => 0,
+            _ => 1,
+        }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -30,8 +30,8 @@ mod tests {
 
     const SAMPLE_DOCKER: &str =
         "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample";
-    const ENCLAVE_SDK_DOCKER: &str =
-        "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:enclave-sdk";
+    const COMMAND_EXECUTER_DOCKER: &str =
+        "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:command-executer";
 
     pub const MAX_BOOT_TIMEOUT_SEC: u64 = 9;
 
@@ -121,12 +121,12 @@ mod tests {
     }
 
     #[test]
-    fn build_enclaves_enclave_sdk() {
+    fn build_enclaves_command_executer() {
         let dir = tempdir().unwrap();
         let eif_path = dir.path().join("test.eif");
         setup_env();
         let args = BuildEnclavesArgs {
-            docker_uri: ENCLAVE_SDK_DOCKER.to_string(),
+            docker_uri: COMMAND_EXECUTER_DOCKER.to_string(),
             docker_dir: None,
             output: eif_path.to_str().unwrap().to_string(),
             signing_certificate: None,
@@ -144,7 +144,7 @@ mod tests {
         .1;
         assert_eq!(
             measurements.get("PCR0").unwrap(),
-            "92c58dd8603a5fc57493c0cf78d726840e3e3dc728444e244f02e03ba5fa353d7cab2b7aeaa8627d26e7464808d864fd"
+            "064a6a5fc90aebcbe195678bb9c332df7b3a50449826e5aff990f75a51348669cfa69850e88ac33e28be37cf9be1b17c"
         );
         assert_eq!(
             measurements.get("PCR1").unwrap(),
@@ -152,7 +152,7 @@ mod tests {
         );
         assert_eq!(
             measurements.get("PCR2").unwrap(),
-            "bd60ceba51d463a519545688123a91fd88b798405034b1dae256bfc3559d9e48b3be63b073ebcb9e0aa506235774d514"
+            "6230ddd55a64440e2dcca604961e0457bd4de358fd719269c7c3081ced00dc4b2abf0df5248d84a778873425ed7b7797"
         );
     }
 
@@ -310,12 +310,12 @@ mod tests {
     }
 
     #[test]
-    fn run_describe_terminate_enclave_sdk_docker_image() {
+    fn run_describe_terminate_command_executer_docker_image() {
         let dir = tempdir().unwrap();
         let eif_path = dir.path().join("test.eif");
         setup_env();
         let build_args = BuildEnclavesArgs {
-            docker_uri: ENCLAVE_SDK_DOCKER.to_string(),
+            docker_uri: COMMAND_EXECUTER_DOCKER.to_string(),
             docker_dir: None,
             output: eif_path.to_str().unwrap().to_string(),
             signing_certificate: None,
@@ -336,7 +336,7 @@ mod tests {
             eif_path: build_args.output,
             cpu_ids: None,
             cpu_count: Some(2),
-            memory_mib: 1024,
+            memory_mib: 2046,
             debug_mode: Some(true),
         };
         run_describe_terminate(args);
@@ -536,10 +536,10 @@ mod tests {
     #[test]
     fn run_describe_terminate_loop() {
         for _ in 0..3 {
-            run_describe_terminate_enclave_sdk_docker_image();
+            run_describe_terminate_command_executer_docker_image();
             run_describe_terminate_simple_docker_image();
             run_describe_terminate_signed_enclave_image();
-            run_describe_terminate_enclave_sdk_docker_image();
+            run_describe_terminate_command_executer_docker_image();
             run_describe_terminate_signed_enclave_image();
         }
     }


### PR DESCRIPTION
Currently, before starting an enclave, the user provided
enclave memory is checked to be at least equal to the EIF
size.
However, this constraint is not strong enough and in order
to ensure there is enough memory to unpack the initramfs,
this commit introduces a lower limit on the enclave memory:
4 times the size of the EIF file.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>

*Issue #, if available: #188, #194, #196*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
