### PR TITLE
allocator-service: added possibility to restart service

### DIFF
--- a/bootstrap/nitro-enclaves-allocator
+++ b/bootstrap/nitro-enclaves-allocator
@@ -127,10 +127,14 @@ function parse_config {
 
 # Set all CPUs online before trying to reconfigure the CPU pool (in case the service is restarted).
 function enable_offline_cpus {
-    offline_cpus=$(cat /sys/devices/system/cpu/offline)
-    for offline_cpu in $(echo $offline_cpus | sed "s/[,-]/ /g"); do
-        echo 1 > /sys/devices/system/cpu/cpu$offline_cpu/online || fail "Failed to re-enable cpu $offline_cpu."
-    done
+    echo "" > /sys/module/nitro_enclaves/parameters/ne_cpus 2> .tmp_file
+    err_info=$(cat .tmp_file)
+    rm .tmp_file
+
+    # Check error code in order to determine if there are any enclaves running
+    if [[ $err_info == *"Operation not permitted"* ]]; then
+	    fail "Could not re-online CPUs because there is at least one enclave currently running. Make sure you stop all enclaves prior to re-starting the nitro-enclaves-allocator.service."
+    fi
 }
 
 # Configure the CPU pool.
@@ -536,9 +540,11 @@ function main() {
 
     local cpu_msg
     if [[ ! -z ${CONFIG[cpu_count]} ]]; then
+        enable_offline_cpus
         cpu_msg="${CONFIG[cpu_count]} CPUs"
         configure_cpu_pool_by_cpu_count "${CONFIG[cpu_count]}" "${CONFIG[memory_mib]}"
     elif [[ ! -z ${CONFIG[cpu_pool]} ]]; then
+        enable_offline_cpus
         cpu_msg="CPU pool: ${CONFIG[cpu_pool]}"
         configure_cpu_pool "${CONFIG[cpu_pool]}"
         configure_huge_pages "${CONFIG[memory_mib]}"


### PR DESCRIPTION
Previously, restarting the allocator service would produce
some errors with regard to the CPUs, when trying to
reserve more than `parent_instance_cpus / 2` CPUs.
This commit fixes the issue, by first bringing back
online the CPUs and then looking for CPUs to include
in the CPU pool.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
