### PR TITLE
nitro-cli: Check debug flag is present for enclave console access

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -191,6 +191,8 @@ pub enum EnclaveProcessCommandType {
     Describe,
     /// Request an enclave's CID (sent by the CLI).
     GetEnclaveCID,
+    /// Request an enclave's flags (sent by the CLI).
+    GetEnclaveFlags,
     /// Notify the socket connection listener to shut down (sent by the enclave process to itself).
     ConnectionListenerStop,
     /// Do not execute a command due to insufficient privileges (sent by the CLI, modified by the enclave process).

--- a/src/enclave_proc/connection.rs
+++ b/src/enclave_proc/connection.rs
@@ -83,11 +83,13 @@ impl CommandRequesterPolicy {
             EnclaveProcessCommandType::TerminateComplete,
             EnclaveProcessCommandType::Describe,
             EnclaveProcessCommandType::GetEnclaveCID,
+            EnclaveProcessCommandType::GetEnclaveFlags,
             EnclaveProcessCommandType::ConnectionListenerStop,
         ];
         let cmds_read_only = vec![
             EnclaveProcessCommandType::Describe,
             EnclaveProcessCommandType::GetEnclaveCID,
+            EnclaveProcessCommandType::GetEnclaveFlags,
         ];
         let mut policy = HashMap::new();
 

--- a/src/enclave_proc/mod.rs
+++ b/src/enclave_proc/mod.rs
@@ -68,6 +68,7 @@ fn get_command_action(cmd: EnclaveProcessCommandType) -> String {
         }
         EnclaveProcessCommandType::Describe => "Describe Enclaves".to_string(),
         EnclaveProcessCommandType::GetEnclaveCID => "Get Enclave CID".to_string(),
+        EnclaveProcessCommandType::GetEnclaveFlags => "Get Enclave Flags".to_string(),
         EnclaveProcessCommandType::ConnectionListenerStop => "Stop Connection Listener".to_string(),
         _ => "Unknown Command".to_string(),
     }
@@ -277,12 +278,27 @@ fn handle_command(
         }
 
         EnclaveProcessCommandType::GetEnclaveCID => {
-            let enclave_cid = enclave_manager.get_console_resources().map_err(|e| {
-                e.set_action("Failed to get console resources (enclave CID)".to_string())
-            })?;
+            let enclave_cid = enclave_manager
+                .get_console_resources_enclave_cid()
+                .map_err(|e| {
+                    e.set_action("Failed to get console resources (enclave CID)".to_string())
+                })?;
             connection.write_u64(enclave_cid).map_err(|e| {
                 e.add_subaction("Failed to write enclave CID to connection".to_string())
                     .set_action("Get Enclave CID".to_string())
+            })?;
+            (0, false)
+        }
+
+        EnclaveProcessCommandType::GetEnclaveFlags => {
+            let enclave_flags = enclave_manager
+                .get_console_resources_enclave_flags()
+                .map_err(|e| {
+                    e.set_action("Failed to get console resources (enclave flags)".to_string())
+                })?;
+            connection.write_u64(enclave_flags).map_err(|e| {
+                e.add_subaction("Failed to write enclave flags to connection".to_string())
+                    .set_action("Get Enclave Flags".to_string())
             })?;
             (0, false)
         }

--- a/src/enclave_proc/resource_manager.rs
+++ b/src/enclave_proc/resource_manager.rs
@@ -926,10 +926,10 @@ impl EnclaveManager {
         ))
     }
 
-    /// Get the resources needed for connecting to the enclave console.
+    /// Get the resources (enclave CID) needed for connecting to the enclave console.
     ///
     /// The enclave handle is locked during this operation.
-    pub fn get_console_resources(&self) -> NitroCliResult<u64> {
+    pub fn get_console_resources_enclave_cid(&self) -> NitroCliResult<u64> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
                 &format!("Failed to acquire lock: {:?}", e),
@@ -937,6 +937,19 @@ impl EnclaveManager {
             )
         })?;
         Ok(locked_handle.enclave_cid.unwrap())
+    }
+
+    /// Get the resources (enclave flags) needed for connecting to the enclave console.
+    ///
+    /// The enclave handle is locked during this operation.
+    pub fn get_console_resources_enclave_flags(&self) -> NitroCliResult<u64> {
+        let locked_handle = self.enclave_handle.lock().map_err(|e| {
+            new_nitro_cli_failure!(
+                &format!("Failed to acquire lock: {:?}", e),
+                NitroCliErrorEnum::LockAcquireFailure
+            )
+        })?;
+        Ok(locked_handle.flags)
     }
 
     /// Get the resources needed for enclave termination.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ mod tests {
     };
     use nitro_cli::common::json_output::EnclaveDescribeInfo;
     use nitro_cli::enclave_proc::commands::{describe_enclaves, run_enclaves, terminate_enclaves};
+    use nitro_cli::enclave_proc::resource_manager::NE_ENCLAVE_DEBUG_MODE;
     use nitro_cli::enclave_proc::utils::{
         flags_to_string, generate_enclave_id, get_enclave_describe_info,
     };
@@ -349,10 +350,18 @@ mod tests {
         let req_nr_cpus: u64 = args.cpu_count.unwrap().try_into().unwrap();
         let debug_mode = args.debug_mode.clone();
         let mut enclave_manager = run_enclaves(&args, None).expect("Run enclaves failed");
-        let enclave_cid = enclave_manager.get_console_resources().unwrap();
+        let enclave_cid = enclave_manager.get_console_resources_enclave_cid().unwrap();
+        let enclave_flags = enclave_manager
+            .get_console_resources_enclave_flags()
+            .unwrap();
         if let Some(req_enclave_cid) = req_enclave_cid {
             assert_eq!(req_enclave_cid, enclave_cid);
         }
+
+        match debug_mode {
+            Some(true) => assert_eq!(enclave_flags & NE_ENCLAVE_DEBUG_MODE, NE_ENCLAVE_DEBUG_MODE),
+            _ => assert_eq!(enclave_flags & NE_ENCLAVE_DEBUG_MODE, 0),
+        };
 
         let cid_copy = enclave_cid;
 
@@ -462,7 +471,15 @@ mod tests {
         };
 
         let mut enclave_manager = run_enclaves(&run_args, None).expect("Run enclaves failed");
-        let enclave_cid = enclave_manager.get_console_resources().unwrap();
+        let enclave_cid = enclave_manager.get_console_resources_enclave_cid().unwrap();
+        let enclave_flags = enclave_manager
+            .get_console_resources_enclave_flags()
+            .unwrap();
+
+        match run_args.debug_mode {
+            Some(true) => assert_eq!(enclave_flags & NE_ENCLAVE_DEBUG_MODE, NE_ENCLAVE_DEBUG_MODE),
+            _ => assert_eq!(enclave_flags & NE_ENCLAVE_DEBUG_MODE, 0),
+        };
 
         let info = get_enclave_describe_info(&enclave_manager).unwrap();
         let replies: Vec<EnclaveDescribeInfo> = vec![info];
@@ -505,7 +522,15 @@ mod tests {
         };
 
         let mut enclave_manager = run_enclaves(&run_args, None).expect("Run enclaves failed");
-        let enclave_cid = enclave_manager.get_console_resources().unwrap();
+        let enclave_cid = enclave_manager.get_console_resources_enclave_cid().unwrap();
+        let enclave_flags = enclave_manager
+            .get_console_resources_enclave_flags()
+            .unwrap();
+
+        match run_args.debug_mode {
+            Some(true) => assert_eq!(enclave_flags & NE_ENCLAVE_DEBUG_MODE, NE_ENCLAVE_DEBUG_MODE),
+            _ => assert_eq!(enclave_flags & NE_ENCLAVE_DEBUG_MODE, 0),
+        };
 
         let info = get_enclave_describe_info(&enclave_manager).unwrap();
         let replies: Vec<EnclaveDescribeInfo> = vec![info];


### PR DESCRIPTION
The enclave needs to be started in debug mode to get its console output.
Check the enclave flags and early exit if the debug mode flag is not
set when the enclave is created.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #193*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
