### PR TITLE
packaging: Prevent file erasure on package upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "nitro-cli"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "bindgen",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitro-cli"
-version = "1.0.8"
+version = "1.0.9"
 authors = ["Alexandru Gheorghe <aggh@amazon.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Currently, plain RPM package upgrades leave the nitro-cli
into an unusable state, since the post-uninstall scriptlet
removes necessary files and directories.

Checking the package operation in both pre and post
uninstall is necessary in order to successfully run
nitro-cli commands after performing an install operation
(e.g. `sudo yum update aws-nitro-enclaves-cil`).
The meaning of the parameter values are described here:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/.

Instead of relying on the user to manually update his
already installed v1.0-5 of the Nitro CLI package, this
commit introduces a separate `%posttrans` scriptlet
that currently performs the same `%post` steps as before,
in order to reconfigure the environment after the old
package version uninstall.
    
This commit also updates the package version to 1.1-1.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
