### PR TITLE
Bump yaml-rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "linked_hash_set"
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]


### PR DESCRIPTION
This PR fixes a bug in `yaml-rust` that causes the following error

```
thread 'main' panicked at 'attempted to leave type `linked_hash_map::Node<yaml::Yaml, yaml::Yaml>` uninitialized, which is invalid', /rustc/e1884a8e3c3e813aada8254edfa120e85bf5ffca/library/core/src/mem/mod.rs:659:9
stack backtrace:
<snip>
             at ./rustc/e1884a8e3c3e813aada8254edfa120e85bf5ffca/library/core/src/mem/mod.rs:659:9
   4: linked_hash_map::LinkedHashMap<K,V,S>::ensure_guard_node
             at ./home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/linked-hash-map-0.5.2/src/lib.rs:174:52
   5: linked_hash_map::LinkedHashMap<K,V,S>::insert
             at ./home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/linked-hash-map-0.5.2/src/lib.rs:304:9
   6: <serde_yaml::ser::SerializeStruct as serde::ser::SerializeStruct>::serialize_field
<snip>
             at ./home/rust/src/enclave_build/src/yaml_generator.rs:8:17
  17: serde::ser::impls::<impl serde::ser::Serialize for &T>::serialize
             at ./home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.105/src/ser/impls.rs:390:17
  18: serde_yaml::ser::to_yaml
             at ./home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_yaml-0.8.11/src/ser.rs:448:5
  19: serde_yaml::ser::to_writer
             at ./home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_yaml-0.8.11/src/ser.rs:394:15
  20: serde_yaml::ser::to_vec
             at ./home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_yaml-0.8.11/src/ser.rs:411:5
  21: serde_yaml::ser::to_string
             at ./home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/serde_yaml-0.8.11/src/ser.rs:423:26
  22: enclave_build::yaml_generator::YamlGenerator::get_bootstrap_ramfs
             at ./home/rust/src/enclave_build/src/yaml_generator.rs:93:20
<snip>
```

The fix is the same as in https://github.com/dtolnay/serde-yaml/issues/182#issuecomment-735997615:
```
❯ cargo update -p yaml-rust --precise 0.4.5
    Updating crates.io index
    Updating linked-hash-map v0.5.2 -> v0.5.3
    Updating yaml-rust v0.4.3 -> v0.4.5
```