### PR TITLE
deps: Update vendorized dependencies

### DIFF
--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-309bbd353739a304da9cf6f7bf67f96c1763e7f1 nitro-cli-dependencies.tar.gz
+48412819fa7c7ee7c09a186dced3a71a1d4592cf  nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
Ran `make update-crates-dependencies` to update
the vendorized dependencies in the S3 bucket.

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
