### PR TITLE
eif: Add EIF header architecture flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "clap",
+ "eif_defs",
  "eif_utils",
  "log",
  "serde",

--- a/eif_defs/src/lib.rs
+++ b/eif_defs/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(warnings)]
@@ -18,6 +18,10 @@ use std::mem::size_of;
 
 pub const EIF_MAGIC: [u8; 4] = [46, 101, 105, 102]; // .eif in ascii
 pub const MAX_NUM_SECTIONS: usize = 32;
+/// EIF Header Flags
+/// bits 1  : Architecture - toggled for aarch64, cleared for x86_64
+/// bits 2-8: Unused
+pub const EIF_HDR_ARCH_ARM64: u16 = 0x1;
 
 /// Current EIF version to be incremented every time we change the format
 /// of this structures, we assume changes are backwards compatible.
@@ -31,6 +35,7 @@ pub struct EifHeader {
     pub magic: [u8; 4],
     /// EIF version
     pub version: u16,
+    /// EIF header flags
     pub flags: u16,
     /// Default enclave memory used to boot this eif file
     pub default_mem: u64,

--- a/eif_utils/src/bin/eif_build.rs
+++ b/eif_utils/src/bin/eif_build.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(warnings)]
@@ -173,6 +173,7 @@ pub fn build_eif<T: Digest + Debug + Write + Clone>(
         cmdline.to_string(),
         sign_info,
         hasher.clone(),
+        0, // flags
     );
     for ramdisk in ramdisks {
         build.add_ramdisk(Path::new(ramdisk));

--- a/eif_utils/src/lib.rs
+++ b/eif_utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(warnings)]
@@ -67,6 +67,7 @@ pub struct EifBuilder<T: Digest + Debug + Write + Clone> {
     sign_info: Option<SignEnclaveInfo>,
     signature: Option<Vec<u8>>,
     signature_size: u64,
+    eif_hdr_flags: u16,
     default_mem: u64,
     default_cpus: u64,
     /// Hash of the whole EifImage.
@@ -88,6 +89,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
         cmdline: String,
         sign_info: Option<SignEnclaveInfo>,
         hasher: T,
+        flags: u16,
     ) -> Self {
         let kernel_file = File::open(kernel_path).expect("Invalid kernel path");
         let cmdline = CString::new(cmdline).expect("Invalid cmdline");
@@ -98,6 +100,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
             sign_info,
             signature: None,
             signature_size: 0,
+            eif_hdr_flags: flags,
             default_mem: 1024 * 1024 * 1024,
             default_cpus: 2,
             image_hasher: EifHasher::new_without_cache(hasher.clone())
@@ -247,7 +250,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
         EifHeader {
             magic: EIF_MAGIC,
             version: eif_defs::CURRENT_VERSION,
-            flags: 0,
+            flags: self.eif_hdr_flags,
             default_mem: self.default_mem,
             default_cpus: self.default_cpus,
             reserved: 0,

--- a/enclave_build/Cargo.toml
+++ b/enclave_build/Cargo.toml
@@ -19,4 +19,5 @@ log = "0.4"
 url = "2.1"
 sha2 = "0.8"
 
+eif_defs = { path = "../eif_defs" }
 eif_utils = { path = "../eif_utils" }


### PR DESCRIPTION
When building an EIF image, inspect the source docker
image and based on its architecture (i.e. amd64 vs aarch64)
set the flag accordingly in the EIF header flags.

This flag shall be cleared for amd64 and toggled for aarch64.

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
