### PR TITLE
clippy: Fix rustfmt & clippy errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ fn get_gcc_sysroot() -> String {
         output = Command::new(cc).arg("--print-sysroot").output();
     }
 
-    if let Err(_) = output {
+    if output.is_err() {
         // Otherwise, try to guess the compiler's name by the name
         // $TARGET-gcc, where $TARGET represents the target architecture
         // that was specified for build
@@ -31,7 +31,7 @@ fn get_gcc_sysroot() -> String {
         output = Command::new(format!("{}-gcc", target))
             .arg("--print-sysroot")
             .output();
-        if let Err(_) = output {
+        if output.is_err() {
             // If that did not work as well, use directly `gcc`
             output = Command::new("gcc").arg("--print-sysroot").output();
         }

--- a/enclave_build/src/docker.rs
+++ b/enclave_build/src/docker.rs
@@ -304,7 +304,7 @@ impl DockerUtil {
                 .map(|image| {
                     (
                         image.config.entrypoint.unwrap(),
-                        image.config.env.ok_or(Vec::<String>::new()).unwrap(),
+                        image.config.env.ok_or_else(Vec::<String>::new).unwrap(),
                     )
                 })
                 .map_err(|e| {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -98,7 +98,7 @@ do
 
 	configure_ne_driver
 
-	./build/nitro_cli/x86_64-unknown-linux-musl/release/"${test_exec_name}" \
+	./build/nitro_cli/x86_64-unknown-linux-musl/release/deps/"${test_exec_name}" \
 		--test-threads=1 --nocapture || test_failed
 done < <(grep -v '^ *#' < build/test_executables.txt)
 

--- a/src/common/document_errors.rs
+++ b/src/common/document_errors.rs
@@ -365,175 +365,181 @@ pub fn explain_error(error_code_str: String) {
     match error_code_str.as_str() {
         "E00" => {
             eprintln!("Unspecified error. This is used as a catch-all error and should not be used in the code.");
-        },
+        }
         "E01" => {
             eprintln!("Missing mandatory argument. Such error appears when the Nitro CLI is requested to perform an operation, but not all of the mandatory arguments were supplied.\n\tExample: `nitro-cli run-enclave --cpu-count 2 --eif-path /path/to/my/eif`. Note that in this case, the mandatory parameter `--memory` is missing a value.");
-        },
+        }
         "E02" => {
             eprintln!("CLI conflicting arguments. Such error appears when the Nitro CLI is supplied two contradicting arguments at the same time, such as `--cpu-count` and `--cpu-ids`.\nIn this case, only one of the parameters should be supplied.");
-        },
+        }
         "E03" => {
             eprintln!("Invalid argument provided. Such error appears when the type of at least one of the arguments provided to the Nitro CLI does not match the expected type of that parameter.\n\tExample: `nitro-cli run-enclave --cpu-count 1z --memory 80 --eif-path /path/to/my/eif`. In this case, `cpu-count` is not a valid integer value." );
-        },
+        }
         "E04" => {
             eprintln!("Socket pair creation failure. Such error apears when the Nitro CLI process attempts to open a stream pair in order to send a command to the enclave process, but the stream initialization fails.");
-        },
+        }
         "E05" => {
             eprintln!("Process spawn failure. Such error appears when the main Nitro CLI process failed to spawn the enclave process, in order to complete a `run-enclave` command.");
-        },
+        }
         "E06" => {
             eprintln!("Daemonize process failure. Such error appears when the system fails to daemonize the newly spawned enclave process.")
-        },
+        }
         "E07" => {
             eprintln!("Read from disk failure. Such error appears when the Nitro CLI process fails to read the content of the enclave sockets directory (usually '/run/nitro_enclaves/') in order to perform a `describe-enclave` operation. Check that the directory exists and it has proper permissions, or run the Nitro Enclaves configuration script in order to (re)configure the environment.");
-        },
+        }
         "E08" => {
             eprintln!("Unusable connection error. Such error appears when the Nitro CLI process attempts to open a connection to a non-existing or previously closed enclave descriptor");
-        },
+        }
         "E09" => {
             eprintln!("Socket close error. Such error appears when the system fails to successfully close a communication channel.");
-        },
+        }
         "E10" => {
             eprintln!("Socket connect set timeout error. Such error appears when the system fails to configure a specific timeout for a given socket. May arise when trying to connect to an enclave's console.");
-        },
+        }
         "E11" => {
             eprintln!("Socket error. This is used as an error for catching any other socket operation errors not covered by previous custom errors.");
-        },
+        }
         "E12" => {
             eprintln!("Epoll error. Such error appears, for instance, when the system fails to register a specific enclave descriptor with epoll in order to monitor events for it.");
         }
         "E13" => {
             eprintln!("Inotify error. Such error appears when the system fails to configure a socket for monitorization.");
-        },
+        }
         "E14" => {
             eprintln!("Invalid command. Such error appears when an unknown command and / or unknown arguments are sent through a socket.");
-        },
+        }
         "E15" => {
             eprintln!("Lock acquire failure. Such error appears when the system fails to obtain the lock for an object with concurrent access, such as a structure containing information about a running enclave.");
-        },
+        }
         "E16" => {
             eprintln!("Thread join failure. Such error appears when the system fails to successfully join a thread, after it finished executing.");
-        },
+        }
         "E17" => {
             eprintln!("Serde error. Such error appears when serializing / deserializing a command or response fails.");
-        },
+        }
         "E18" => {
             eprintln!("File permissions error. Such error appears when a user other than the owner of the logging file (usually '/var/log/nitro_enclaves/nitro_enclaves.log') attempts to change the file permissions");
-        },
+        }
         "E19" => {
             eprintln!("File operation failure. Such error appears when the system fails to perform the requested file operations, such as opening the EIF file when launching an enclave, or seeking to a specific offset in the EIF file, or writing to the log file.");
-        },
+        }
         "E20" => {
             eprintln!("Invalid CPU configuration. Such error appears when the user supplies the same CPU ID multiple times.\n\tExample: `nitro-cli run-enclave --cpu-ids 1 1 --memory 80 --eif-path /path/to/my/eif`. In this case, CPU ID `1` has been selected twice.");
-        },
+        }
         "E21" => {
             eprintln!("No such CPU available in the pool. Such error appears when the user requests to run an enclave with at least one CPU ID which does not exist in the CPU pool.\n\tExample: (configured CPU pool: [1,9]) `nitro-cli run-enclave --cpu-ids 1 2 --memory 80 --eif-path /path/to/my/eif`. In this case, CPU 2 is not in the configured CPU pool.");
-        },
+        }
         "E22" => {
             eprintln!("Insufficient CPUs available in the pool. Such error appears when the user requests to run an enclave with more CPUs that available in the CPU pool.\n\tExample: (configured CPU pool: [1,9]) `nitro-cli run-enclave --cpu-count 4 --memory 80 --eif-path /path/to/my/eif`. In this case, the user requested 4 CPUs, but the CPU pool contains only 2.");
-        },
+        }
         "E23" => {
             eprintln!("Malformed CPU ID error. Such error appears when a `lscpu` line is malformed and reports an invalid online CPUs list.");
-        },
+        }
         "E24" => {
-            eprintln!("CPU error. Such error appears when a CPU line interval is invalid (as in 0-3-7)");
-        },
+            eprintln!(
+                "CPU error. Such error appears when a CPU line interval is invalid (as in 0-3-7)"
+            );
+        }
         "E25" => {
             eprintln!("No such hugepage flag error. Such error appears when the enclave process attempts to use an invalid hugepage size (size other than the known hugepage sizes) for initializing the enclave memory.");
-        },
+        }
         "E26" => {
             eprintln!("Insufficient memory requested. Such error appears when the user requests to launch an enclave with not enough memory. The enclave memory should be at least equal to the size of the EIF file used for launching the enclave.\n\tExample: (EIF file size: 11MB) `nitro-cli run-enclave --cpu-count 2 --memory 5 --eif-path /path/to/my/eif`. In this case, the user requested to run an enclave with only 5MB of memory, whereas the EIF file alone requires 11MB.");
-        },
+        }
         "E27" => {
             eprintln!("Insufficient memory available. Such error appears when the user requests to launch an enclave with more memory than available. The enclave memory should be at most equal to the size of the configured hugepage memory.\n\tExample: (previously configured 80MB of hugepage memory) `nitro-cli run-enclave --cpu-count 2 --memory 100 --eif-path /path/to/my/eif`. In this case, the user requested to run an enclave with 100MB of memory, whereas the system has only 80MB available for enclaves. As a solution, (re)configure the Nitro Enclaves environment, specifying a higher value for the available memory.");
-        },
+        }
         "E28" => {
             eprintln!("Invalid enclave descriptor. Such error appears when the NE_CREATE_VM ioctl returns with an error.");
-        },
+        }
         "E29" => {
             eprintln!("Ioctl failure. Such error is used as a general ioctl error and appears whenever an ioctl fails. In this case, the error backtrace provides detailed information on what specifically failed during the ioctl.");
-        },
+        }
         "E30" => {
             eprintln!("Ioctl image get load info failure. Such error appears when the ioctl used for getting the memory load information fails. In this case, the error backtrace provides detailed information on what specifically failed during the ioctl.");
-        },
+        }
         "E31" => {
             eprintln!("Ioctl set memory region failure. Such error appears when the ioctl used for setting a given memory region fails. In this case, the error backtrace provides detailed information on what specifically failed during the ioctl.");
-        },
+        }
         "E32" => {
             eprintln!("Ioctl add vCPU failure. Such error appears when the ioctl used for adding a vCPU fails. In this case, the error backtrace provides detailed information on what specifically failed during the ioctl.");
-        },
+        }
         "E33" => {
             eprintln!("Ioctl start enclave failure. Such error appears when the ioctl used for starting an enclave fails. In this case, the error backtrace provides details information on what specifically failed during the ioctl.");
-        },
+        }
         "E34" => {
             eprintln!("Memory overflow. Such error may appear during loading the EIF in the memory regions which will be conceded to the future enclave, if the regions offset plus the EIF file size exceeds the maximum address of the target platform.");
-        },
+        }
         "E35" => {
             eprintln!("EIF file parsing error. Such error appears when attempting to fill a memory region with a section of the EIF file, but reading the entire section fails.");
-        },
+        }
         "E36" => {
             eprintln!("Enclave boot failure. Such error appears when attempting to receive the `ready` signal from a freshly booted enclave. It arises in several contexts, for instance, when the enclave is booted from an invalid EIF file and the enclave process immediately exits, failing to submit the `ready` signal. In this case, the error backtrace provides detailed information on what specifically failed during the enclave boot process.");
-        },
+        }
         "E37" => {
             eprintln!("Enclave event wait error. Such error appears when monitoring an enclave descriptor for events fails.");
-        },
+        }
         "E38" => {
             eprintln!("Enclave process command not executed error. Such error appears when at least one enclave fails to provide the description information.");
-        },
+        }
         "E39" => {
             eprintln!("Enclave process connection failure. Such error appears when the enclave manager fails to connect to at least one enclave process for retrieving the description information.");
-        },
+        }
         "E40" => {
             eprintln!("Socket path not found. Such error appears when the Nitro CLI process fails to build the corresponding socket path starting from a given enclave ID.");
-        },
+        }
         "E41" => {
             eprintln!("Enclave process send reply failure. Such error appears when the enclave process fails to submit the status code to the Nitro CLI process after performing a run / describe / terminate command.");
-        },
+        }
         "E42" => {
-            eprintln!("Enclave mmap error. Such error appears when allocating the enclave memory fails.");
-        },
+            eprintln!(
+                "Enclave mmap error. Such error appears when allocating the enclave memory fails."
+            );
+        }
         "E43" => {
-            eprintln!("Enclave munmap error. Such error appears when unmapping the enclave memory fails.");
-        },
+            eprintln!(
+                "Enclave munmap error. Such error appears when unmapping the enclave memory fails."
+            );
+        }
         "E44" => {
             eprintln!("Enclave console connection failure. Such error appears when the Nitro CLI process fails to establish a connection to a running enclave's console.");
-        },
+        }
         "E45" => {
             eprintln!("Enclave console read error. Such error appears when reading from a running enclave's console fails.");
-        },
+        }
         "E46" => {
             eprintln!("Enclave console write output error. Such error appears when writing the information retrieved from a running enclave's console (to a given stream) fails.");
-        },
+        }
         "E47" => {
             eprintln!("Integer parsing error. Such error appears when trying to connect to a running enclave's console, but the enclave CID cannot be parsed correctly.");
-        },
+        }
         "E48" => {
             eprintln!("EIF building error. Such error appears when trying to build an EIF file. In this case, the error backtrace provides detailed information on the failure reason.");
-        },
+        }
         "E49" => {
             eprintln!("Docker image build error. Such error appears when trying to build and EIF file, but building the corresponding docker image fails. In this case, the error backtrace provides detailed information on the failure reason.");
-        },
+        }
         "E50" => {
             eprintln!("Docker image pull error. Such error appears when trying to build an EIF file, but pulling the corresponding docker image fails. In this case, the error backtrace provides detailed informatino on the failure reason.");
-        },
+        }
         "E51" => {
             eprintln!("Artifacts path environment variable not set. Such error appears when trying to build an EIF file, but the artifacts path environment variable is not set.");
-        },
+        }
         "E52" => {
             eprintln!("Blobs path environment variable not set. Such error appears when trying to build an EIF file, but the blobs path environment variable is not set.");
-        },
+        }
         "E53" => {
             eprintln!("Clock skew error. Such error appears when continuously reading from a running enclave's console, but measuring the time elapsed between consecutive reads failed.");
-        },
+        }
         "E54" => {
             eprintln!("Signal masking error. Such error appears if attempting to mask specific signals before creating an enclave process fails.");
-        },
+        }
         "E55" => {
             eprintln!("Signal unmasking error. Such error appears if attempting to unmask specific signals after creating an enclave process fails.");
-        },
+        }
         "E56" => {
             eprintln!("Logger error. Such error appears when attempting to initialize the underlying logging system fails.");
-        },
+        }
         _ => {
             eprintln!("No such error code {}", error_code_str);
         }

--- a/src/enclave_proc/connection.rs
+++ b/src/enclave_proc/connection.rs
@@ -100,10 +100,7 @@ impl CommandRequesterPolicy {
         );
 
         // The root user may issue any command.
-        policy.insert(
-            CommandRequesterType::User(0 as libc::uid_t),
-            cmds_read_write,
-        );
+        policy.insert(CommandRequesterType::User(0_u32), cmds_read_write);
 
         // All other users may only issue read-only commands.
         policy.insert(CommandRequesterType::Others, cmds_read_only);

--- a/src/enclave_proc/resource_manager.rs
+++ b/src/enclave_proc/resource_manager.rs
@@ -672,7 +672,7 @@ impl EnclaveHandle {
         match cpu_config {
             EnclaveCpuConfig::List(cpu_ids) => {
                 for cpu_id in cpu_ids {
-                    self.init_single_cpu(cpu_id.clone()).map_err(|e| {
+                    self.init_single_cpu(cpu_id).map_err(|e| {
                         e.add_subaction(format!("Failed to add CPU with ID {}", cpu_id))
                     })?;
                 }

--- a/tools/Dockerfile1804
+++ b/tools/Dockerfile1804
@@ -28,7 +28,7 @@ RUN unzip /openssl_src/${OPENSSL_VERSION}.zip -d /openssl_src
 RUN cd /openssl_src/openssl-${OPENSSL_VERSION} && CC=musl-gcc CFLAGS=-fPIC ./Configure --prefix=/musl_openssl --openssldir=/musl_openssl no-shared no-engine no-afalgeng linux-x86_64 -DOPENSSL_NO_SECURE_MEMORY && make && make install
 
 # Setup the right rust ver
-ENV RUST_VERSION=1.41.1
+ENV RUST_VERSION=1.49.0
 RUN  source $HOME/.cargo/env && \
      rustup toolchain install ${RUST_VERSION}-x86_64-unknown-linux-gnu
 RUN  source $HOME/.cargo/env && \

--- a/vsock_proxy/src/main.rs
+++ b/vsock_proxy/src/main.rs
@@ -7,13 +7,13 @@
 /// vsock-proxy 8000 127.0.0.1 9000
 ///
 use clap::{App, AppSettings, Arg};
-use env_logger;
+use env_logger::init;
 use log::info;
 
 use vsock_proxy::starter::{Proxy, VsockProxyResult};
 
 fn main() -> VsockProxyResult<()> {
-    env_logger::init();
+    init();
 
     let matches = App::new("Vsock-TCP proxy")
         .about("Vsock-TCP proxy")


### PR DESCRIPTION
This commit solves several errors reported
by rustfmt and clippy as a result of updating to
rust 1.49

Signed-off-by: Gabriel Bercaru <bercarug@amazon.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
