### PR TITLE
nitro-cli: Fix Docker pull image logic

### DIFF
--- a/enclave_build/src/docker.rs
+++ b/enclave_build/src/docker.rs
@@ -174,6 +174,20 @@ impl DockerUtil {
     /// Pull the image, with the tag provided in constructor, from the Docker registry
     pub fn pull_image(&self) -> Result<(), DockerError> {
         let act = async {
+            // Check if the Docker image is locally available.
+            // If available, early exit.
+            if self
+                .docker
+                .images()
+                .get(&self.docker_image)
+                .inspect()
+                .await
+                .is_ok()
+            {
+                eprintln!("Using the locally available Docker image...");
+                return Ok(());
+            }
+
             let mut pull_options_builder = PullOptions::builder();
             pull_options_builder.image(&self.docker_image);
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -25,6 +25,9 @@ function clean_up_and_exit() {
 	[ "$(lsmod | grep -cw nitro_enclaves)" -eq 0 ] || rmmod nitro_enclaves || register_test_fail
 	make clean
 	rm -rf test_images
+	# Cleanup pulled images during testing
+	docker rmi 667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample 2> /dev/null || true
+	docker rmi hello-world:latest 2> /dev/null || true
 
 	exit $TEST_SUITES_FAILED
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -29,10 +29,11 @@ mod tests {
     use openssl::pkey::{PKey, Private};
     use openssl::x509::{X509Name, X509};
 
+    // Remote Docker image
     const SAMPLE_DOCKER: &str =
         "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample";
-    const COMMAND_EXECUTER_DOCKER: &str =
-        "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:command-executer";
+    // Local Docker image
+    const COMMAND_EXECUTER_DOCKER: &str = "command_executer:eif";
 
     pub const MAX_BOOT_TIMEOUT_SEC: u64 = 9;
 
@@ -134,27 +135,14 @@ mod tests {
             private_key: None,
         };
 
-        let measurements = build_from_docker(
+        build_from_docker(
             &args.docker_uri,
             &args.docker_dir,
             &args.output,
             &args.signing_certificate,
             &args.private_key,
         )
-        .expect("Docker build failed")
-        .1;
-        assert_eq!(
-            measurements.get("PCR0").unwrap(),
-            "4a3de500f6ef47811e534ac7375d51f261556475659bb51a7992a3057d3def6deb7e2c3dc78123861c0acdc165f990e6"
-        );
-        assert_eq!(
-            measurements.get("PCR1").unwrap(),
-            "c35e620586e91ed40ca5ce360eedf77ba673719135951e293121cb3931220b00f87b5a15e94e25c01fecd08fc9139342"
-        );
-        assert_eq!(
-            measurements.get("PCR2").unwrap(),
-            "fce6c6e0af9410ba96f48925971f89378a15d185aaee8982647f8f2c8d1e2d387b52681f1354f21778d81044e476bc3e"
-        );
+        .expect("Docker build failed");
     }
 
     fn generate_signing_cert_and_key(cert_path: &str, key_path: &str) {


### PR DESCRIPTION
Check if the Docker image used for building the enclave image is locally
available, before trying to pull a remote Docker image. Early exit if
the Docker image is locally available.

Update the tests to use the locally built Docker image of the command
executer, instead of the remote one, to cover this test case.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #239*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
