### PR TITLE
Makefile: Add target for updating THIRD_PARTY_LICENSES_RUST_CRATES.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,16 @@ nitro-about: build-setup build-container
 			generate /nitro_src/about.hbs | \
 			diff /nitro_src/THIRD_PARTY_LICENSES_RUST_CRATES.html -'
 
+.PHONY: update-third-party-licenses-rust-crates-html
+update-third-party-licenses-rust-crates-html: build-setup build-container
+	$(DOCKER) run \
+		-v "$$(readlink -f ${BASE_PATH})":/nitro_src \
+		-v "$$(readlink -f ${OBJ_PATH})":/nitro_build \
+		$(CONTAINER_TAG) bin/bash -c \
+			'source /root/.cargo/env && \
+			cargo about --manifest-path=/nitro_src/Cargo.toml \
+			generate /nitro_src/about.hbs > /nitro_src/THIRD_PARTY_LICENSES_RUST_CRATES.html'
+
 # See .build-container rule for explanation.
 .build-vsock-proxy: $(shell find $(BASE_PATH)/vsock_proxy/src -name "*.rs")
 	$(DOCKER) run \


### PR DESCRIPTION
When the Rust crates dependencies are updated, the information about
licenses in THIRD_PARTY_LICENSES_RUST_CRATES.html has to be updated.

Add a Makefile target to generate the updated version of the
THIRD_PARTY_LICENSES_RUST_CRATES.html file, to be used when there are
changes in the Rust crates dependencies.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
