### PR TITLE
vsock_proxy: Update nitro-enclaves-vsock-proxy service to use IMDSv2

### DIFF
--- a/vsock_proxy/service/nitro-enclaves-vsock-proxy.service
+++ b/vsock_proxy/service/nitro-enclaves-vsock-proxy.service
@@ -8,7 +8,8 @@ Type=simple
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=vsock-proxy
-ExecStart=/bin/bash -ce "REGION=$(curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region) ; \
+ExecStart=/bin/bash -ce "TOKEN=$(curl --silent -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\") ; \
+			REGION=$(curl --silent -H \"X-aws-ec2-metadata-token: $TOKEN\" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region) ; \
 			exec /usr/bin/vsock-proxy 8000 kms.$${REGION}.amazonaws.com 443 \
                 --config /etc/nitro_enclaves/vsock-proxy.yaml"
 Restart=always


### PR DESCRIPTION
The start command for the nitro-enclaves-vsock-proxy service uses IMDS
to retrieve the region corresponding to the running instance.

Update the start command to use IMDSv2.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*

Documentation for IMDSv2: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
