### PR TITLE
vsock_proxy: Add fallback to IMDSv1 if IMDSv2 not available

### DIFF
--- a/vsock_proxy/service/nitro-enclaves-vsock-proxy.service
+++ b/vsock_proxy/service/nitro-enclaves-vsock-proxy.service
@@ -10,6 +10,7 @@ StandardError=journal
 SyslogIdentifier=vsock-proxy
 ExecStart=/bin/bash -ce "TOKEN=$(curl --silent -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\") ; \
 			REGION=$(curl --silent -H \"X-aws-ec2-metadata-token: $TOKEN\" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region) ; \
+			[ -z \"$REGION\" ] && REGION=$(curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region) ; \
 			exec /usr/bin/vsock-proxy 8000 kms.$${REGION}.amazonaws.com 443 \
                 --config /etc/nitro_enclaves/vsock-proxy.yaml"
 Restart=always


### PR DESCRIPTION
The configuration for the vsock-proxy service has been updated to use
IMDSv2. Add fallback to IMDSv1 if IMDSv2 is not available.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
