### PR TITLE
nitro-cli-config: Fix setup for the enclave process sockets directory

### DIFF
--- a/bootstrap/nitro-cli-config
+++ b/bootstrap/nitro-cli-config
@@ -438,7 +438,8 @@ function configure_resource_directory {
 # Configure the resource directories for Nitro CLI logging and sockets.
 function configure_resource_directories {
     # Configure the directory that will hold enclave process sockets.
-    configure_resource_directory "/var/run/$RES_DIR_NAME"
+    sudo_run "echo \"d /run/$RES_DIR_NAME 0775 root $NE_GROUP_NAME\" > /usr/lib/tmpfiles.d/$RES_DIR_NAME.conf" || fail "Could not configure the directory for the enclave process sockets - /run/$RES_DIR_NAME"
+    sudo_run "systemd-tmpfiles --create /usr/lib/tmpfiles.d/$RES_DIR_NAME.conf" || fail "Could not make /run/$RES_DIR_NAME available on the system"
 
     # Configure the directory that will hold logs.
     configure_resource_directory "/var/log/$RES_DIR_NAME"


### PR DESCRIPTION
The setup for the enclave process sockets directory was updated in
the nitro-cli codebase and RPM spec, but not in the nitro-cli-config
script.

Update nitro-cli-config to include the necessary steps for setting up
these directory resources.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
