### PR TITLE
nitro_enclaves: Update the version of kernel headers in the Dockerfile

### DIFF
--- a/drivers/virt/nitro_enclaves/Dockerfile
+++ b/drivers/virt/nitro_enclaves/Dockerfile
@@ -4,10 +4,10 @@ RUN apt-get update
 RUN apt-get install -y build-essential gcc make wget
 
 ENV KERNEL_REPO="https://kernel.ubuntu.com/~kernel-ppa/mainline"
-ENV KERNEL_VER="v5.4.101"
+ENV KERNEL_VER="v5.4.100"
 ENV KERNEL_ARCH="amd64"
-ENV KERNEL_HDR="linux-headers-5.4.101-0504101_5.4.101-0504101.202102261049_all.deb"
-ENV KERNEL_HDR_GENERIC="linux-headers-5.4.101-0504101-generic_5.4.101-0504101.202102261049_amd64.deb"
+ENV KERNEL_HDR="linux-headers-5.4.100-0504100_5.4.100-0504100.202102231536_all.deb"
+ENV KERNEL_HDR_GENERIC="linux-headers-5.4.100-0504100-generic_5.4.100-0504100.202102231536_amd64.deb"
 
 RUN wget "$KERNEL_REPO"/"$KERNEL_VER"/"$KERNEL_ARCH"/"$KERNEL_HDR" \
          "$KERNEL_REPO"/"$KERNEL_VER"/"$KERNEL_ARCH"/"$KERNEL_HDR_GENERIC"


### PR DESCRIPTION
Update the version of the kernel headers to a new version since the
current version is not available anymore in the repo.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
