### PR TITLE
integration_tests: Fix race when cleanup nitro-cli process

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -65,8 +65,11 @@ def get_pids(name):
 def kill_all_nitro_processes():
         pids = get_pids("nitro-cli")
         for pid in pids.split():
-                if pid:
-                        os.kill(int(pid), signal.SIGTERM)
+                try:
+                        if pid:
+                                os.kill(int(pid), signal.SIGTERM)
+                except:
+                        print("Caught exception while killing the process");
 
 # Runs a process and checks it returned success
 # Returns an instance of a CompletedProcess


### PR DESCRIPTION
The nitro-cli process could disappear from under us from various
reasons, for example the enclave could be in the process of terminating.

The solution is to catch exceptions when trying to kill the process and
consider them harmless.

Signed-off-by: Alexandru Gheorghe <aggh@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
