### PR TITLE
nitro_enclaves: Update container base image source in Dockerfile

### DIFF
--- a/drivers/virt/nitro_enclaves/Dockerfile
+++ b/drivers/virt/nitro_enclaves/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM public.ecr.aws/lts/ubuntu:latest
 
 RUN apt-get update
 RUN apt-get install -y build-essential gcc make wget


### PR DESCRIPTION
The following error can appear when using the current container setup:

Step 1 : FROM ubuntu:20.04
toomanyrequests: You have reached your pull rate limit. You may
increase the limit by authenticating and upgrading:
https://www.docker.com/increase-rate-limit

Update the source of the container base image to be AWS ECR.

https://gallery.ecr.aws/lts/ubuntu

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
