### PR TITLE
enclave_build: Fix docker image checks during enclave image inspect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,10 +195,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
+name = "cpufeatures"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -750,9 +753,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.87"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libloading"
@@ -1330,13 +1333,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest",
  "opaque-debug",
 ]
@@ -1534,15 +1537,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "libc",
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "winapi",
 ]
 
 [[package]]

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -3269,7 +3269,7 @@ limitations under the License.</pre>
                     
                     <li><a href=" https://github.com/indiv0/lazycell ">lazycell 1.2.1</a></li>
                     
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.87</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.98</a></li>
                     
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.2</a></li>
                     
@@ -4010,13 +4010,13 @@ limitations under the License.
                     
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.9.0</a></li>
                     
-                    <li><a href=" https://github.com/RustCrypto/utils ">cpuid-bool 0.1.2</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.1.5</a></li>
                     
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.9.0</a></li>
                     
                     <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug 0.3.0</a></li>
                     
-                    <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.9.3</a></li>
+                    <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.9.5</a></li>
                     
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -6134,10 +6134,10 @@ DEALINGS IN THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.3.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.8.1</a></li>
                     
                 </ul>
-                <pre class="license-text">Copyright (c) 2020 Tokio Contributors
+                <pre class="license-text">Copyright (c) 2021 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/eif_defs/Cargo.toml
+++ b/eif_defs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sha2 = "0.9.3"
+sha2 = "0.9.5"
 serde = { version = ">=1.0", features = ["derive"] }
 num-traits = "0.2"
 num-derive = "0.3"

--- a/eif_loader/Cargo.toml
+++ b/eif_loader/Cargo.toml
@@ -14,7 +14,7 @@ vsock = "0.1.5"
 
 [dev-dependencies]
 eif_utils = { path = "../eif_utils"}
-sha2 = "0.9.3"
+sha2 = "0.9.5"
 tempfile = "3.1"
 
 [lib]

--- a/eif_utils/Cargo.toml
+++ b/eif_utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33"
-sha2 = "0.9.3"
+sha2 = "0.9.5"
 hex = "0.3.2"
 crc = "1.8"
 eif_defs = { path = "../eif_defs" }

--- a/enclave_build/Cargo.toml
+++ b/enclave_build/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1.0", features = ["rt-multi-thread"] }
 base64 = "0.11"
 log = "0.4"
 url = "2.1"
-sha2 = "0.9.3"
+sha2 = "0.9.5"
 futures = "0.3.13"
 
 eif_defs = { path = "../eif_defs" }

--- a/enclave_build/src/docker.rs
+++ b/enclave_build/src/docker.rs
@@ -277,19 +277,19 @@ impl DockerUtil {
         // First try to find CMD parameters (together with potential ENV bindings)
         let act_cmd = async {
             match self.docker.images().get(&self.docker_image).inspect().await {
-                Ok(image) => Ok(image.config.cmd),
+                Ok(image) => image.config.cmd.ok_or(DockerError::UnsupportedEntryPoint),
                 Err(e) => {
                     error!("{:?}", e);
-                    Err(DockerError::UnsupportedEntryPoint)
+                    Err(DockerError::InspectError)
                 }
             }
         };
         let act_env = async {
             match self.docker.images().get(&self.docker_image).inspect().await {
-                Ok(image) => Ok(image.config.env),
+                Ok(image) => image.config.env.ok_or(DockerError::UnsupportedEntryPoint),
                 Err(e) => {
                     error!("{:?}", e);
-                    Err(DockerError::UnsupportedEntryPoint)
+                    Err(DockerError::InspectError)
                 }
             }
         };
@@ -305,10 +305,13 @@ impl DockerUtil {
         if check_cmd_runtime.is_err() || check_env_runtime.is_err() {
             let act_entrypoint = async {
                 match self.docker.images().get(&self.docker_image).inspect().await {
-                    Ok(image) => Ok(image.config.entrypoint),
+                    Ok(image) => image
+                        .config
+                        .entrypoint
+                        .ok_or(DockerError::UnsupportedEntryPoint),
                     Err(e) => {
                         error!("{:?}", e);
-                        Err(DockerError::UnsupportedEntryPoint)
+                        Err(DockerError::InspectError)
                     }
                 }
             };

--- a/tools/Dockerfile1804.aarch64
+++ b/tools/Dockerfile1804.aarch64
@@ -46,7 +46,7 @@ RUN cd /openssl_src/openssl-${OPENSSL_VERSION} && CC=musl-gcc CFLAGS=-fPIC ./Con
 # Setup the right rust ver
 RUN source $HOME/.cargo/env && \
     rustup target add aarch64-unknown-linux-musl --toolchain ${RUST_VERSION} && \
-    cargo install cargo-audit --version ^0.12
+    cargo install cargo-audit --version ^0.15
 
 # Setup the env for nitro-cli
 RUN mkdir -p /var/log/nitro_enclaves

--- a/tools/Dockerfile1804.x86_64
+++ b/tools/Dockerfile1804.x86_64
@@ -36,7 +36,7 @@ RUN  source $HOME/.cargo/env && \
 RUN  source $HOME/.cargo/env && \
     rustup target add --toolchain ${RUST_VERSION} x86_64-unknown-linux-musl
 RUN  source $HOME/.cargo/env && \
-	cargo install cargo-audit --version ^0.12
+	cargo install cargo-audit --version ^0.15
 RUN  source $HOME/.cargo/env && \
 	cargo install cargo-about --version 0.2.2
 RUN apt-get install -y jq


### PR DESCRIPTION
After updating the enclave build codebase to match a newer version of
the shiplift crate, the async functionality is missing a couple of
checks of the docker image config.

Add the checks to not try later to unwrap a "None" variable.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
