### PR TITLE
vsock-proxy: Fix remote server's matching against allowlist

### DIFF
--- a/vsock_proxy/src/main.rs
+++ b/vsock_proxy/src/main.rs
@@ -81,10 +81,6 @@ fn main() -> VsockProxyResult<()> {
         .value_of("remote_addr")
         // This argument is required, so clap ensures it's available
         .unwrap();
-    let remote_addrs = Proxy::parse_addr(&remote_addr, only_4, only_6)
-        .map_err(|err| format!("Could not parse remote address: {}", err))?;
-    let remote_addr = *remote_addrs.get(0).ok_or("No IP address found")?;
-    info!("Using IP {:?} for the given server", remote_addr);
 
     let remote_port = matches
         .value_of("remote_port")

--- a/vsock_proxy/tests/connection_test.rs
+++ b/vsock_proxy/tests/connection_test.rs
@@ -23,7 +23,7 @@ fn vsock_connect(port: u32) -> VsockStream {
 #[test]
 fn test_tcp_connection() {
     // Proxy will translate from port 8000 vsock to localhost port 9000 TCP
-    let addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)).to_string();
     let mut file = NamedTempFile::new().unwrap();
     file.write_all(
         b"allowlist:\n\
@@ -32,7 +32,7 @@ fn test_tcp_connection() {
     .unwrap();
     let proxy = Proxy::new(
         vsock_proxy::starter::VSOCK_PROXY_PORT,
-        addr,
+        &addr,
         9000,
         2,
         file.path().to_str(),


### PR DESCRIPTION
Allowlist matching is done by comparing the remote server's IP and port
against the IP and port of all allowlist file entries. The IP-based comparison
is prone to occasional false-negative failures - consider a case where a
hostname may resolve to different IP addresses at different times, due to
load-balancing, for example. The following may occur:

1) The IP of a host is obtained at moment T1, with value IP_1
2) Load balancing occurs and the host is switched with another one that has
   a different IP, IP_2
3) The IP of the host as read from the allowlist is obtained at moment T2 > T1
   and because of 2), it resolves to IP_2
4) IP_1 is compared against IP_2 and the check fails, thus preventing the
   vsock-proxy from launching, even though the hostnames are the same.

This change fixes the problem by always attempting to match hostnames first.
The IP comparison now occurs only if the hostname match fails. This way, load
balancing no longer affects the result since the hostnames don't change.

Signed-off-by: Andrei Trandafir <aatrand@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
