### PR TITLE
tools: Fix cargo audit build

### DIFF
--- a/tools/Dockerfile1804.aarch64
+++ b/tools/Dockerfile1804.aarch64
@@ -46,7 +46,7 @@ RUN cd /openssl_src/openssl-${OPENSSL_VERSION} && CC=musl-gcc CFLAGS=-fPIC ./Con
 # Setup the right rust ver
 RUN source $HOME/.cargo/env && \
     rustup target add aarch64-unknown-linux-musl --toolchain ${RUST_VERSION} && \
-    cargo install cargo-audit --version ^0.15
+    cargo install cargo-audit --version 0.15.0 --locked
 
 # Setup the env for nitro-cli
 RUN mkdir -p /var/log/nitro_enclaves

--- a/tools/Dockerfile1804.x86_64
+++ b/tools/Dockerfile1804.x86_64
@@ -36,7 +36,7 @@ RUN  source $HOME/.cargo/env && \
 RUN  source $HOME/.cargo/env && \
     rustup target add --toolchain ${RUST_VERSION} x86_64-unknown-linux-musl
 RUN  source $HOME/.cargo/env && \
-	cargo install cargo-audit --version ^0.15
+	cargo install cargo-audit --version 0.15.0 --locked
 RUN  source $HOME/.cargo/env && \
 	cargo install cargo-about --version 0.2.2
 RUN apt-get install -y jq


### PR DESCRIPTION
The following error appears when trying to build cargo audit using the
current Rust version present in the Dockerfiles (ENV RUST_VERSION=1.49.0).

  Downloaded matches v0.1.8
  Downloaded rustc-demangle v0.1.20
  Downloaded zeroize v1.4.1
error: failed to compile `cargo-audit v0.15.0`, intermediate artifacts can be found at `/tmp/cargo-install0judLM`

Caused by:
  failed to parse manifest at `/root/.cargo/registry/src/github.com-1ecc6299db9ec823/zeroize-1.4.1/Cargo.toml`

Caused by:
  feature `resolver` is required

  this Cargo does not support nightly features, but if you
  switch to nightly channel you can add
  `cargo-features = ["resolver"]` to enable this feature

The latest version of zeroize can be used with Rust version 1.51+.
cargo-audit has included in its Cargo.lock a dependency for zeroize 1.3.0.
cargo install doesn't take into consideration by default the Cargo.lock.

https://doc.rust-lang.org/cargo/commands/cargo-install.html

"By default, the Cargo.lock file that is included with the package will
be ignored. This means that Cargo will recompute which versions of
dependencies to use, possibly using newer versions that have been
released since the package was published. The --locked flag can be used
to force Cargo to use the packaged Cargo.lock file if it is available.
This may be useful for ensuring reproducible builds, to use the exact
same set of dependencies that were available when the package was
published. It may also be useful if a newer version of a dependency is
published that no longer builds on your system, or has other problems.
The downside to using --locked is that you will not receive any fixes or
updates to any dependency. Note that Cargo did not start publishing
Cargo.lock files until version 1.37, which means packages published with
prior versions will not have a Cargo.lock file available."

Add the --locked flag for considering the Cargo.lock file of the
installed package.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
