### PR TITLE
PCR describe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "eif_defs",
  "hex 0.3.2",
  "openssl",
+ "serde",
  "serde_cbor",
  "sha2",
 ]
@@ -860,6 +861,7 @@ dependencies = [
  "clap",
  "eif_defs",
  "eif_loader",
+ "eif_utils",
  "enclave_build",
  "flexi_logger",
  "hex 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,12 +854,15 @@ dependencies = [
 name = "nitro-cli"
 version = "1.0.12"
 dependencies = [
+ "aws-nitro-enclaves-cose",
  "bindgen",
  "chrono",
  "clap",
+ "eif_defs",
  "eif_loader",
  "enclave_build",
  "flexi_logger",
+ "hex 0.3.2",
  "inotify",
  "lazy_static",
  "libc",
@@ -872,6 +875,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "sha2",
  "signal-hook",
  "tempfile",
  "vmm-sys-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,14 @@ signal-hook = "0.3"
 serde_cbor = "0.11"
 eif_loader = { path = "./eif_loader" }
 eif_defs = { path = "./eif_defs" }
+eif_utils = { path = "./eif_utils" }
 enclave_build = { path = "./enclave_build" }
 openssl = "0.10"
 vsock = "0.1.5"
-<<<<<<< HEAD
 vmm-sys-util = "0.8.0"
-=======
 sha2 = "0.9.5"
 hex = "0.3.2"
 aws-nitro-enclaves-cose = "0.1"
->>>>>>> Change saving PCRs to parallel
 
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,17 @@ page_size = "0.4"
 signal-hook = "0.3"
 serde_cbor = "0.11"
 eif_loader = { path = "./eif_loader" }
+eif_defs = { path = "./eif_defs" }
 enclave_build = { path = "./enclave_build" }
 openssl = "0.10"
 vsock = "0.1.5"
+<<<<<<< HEAD
 vmm-sys-util = "0.8.0"
+=======
+sha2 = "0.9.5"
+hex = "0.3.2"
+aws-nitro-enclaves-cose = "0.1"
+>>>>>>> Change saving PCRs to parallel
 
 lazy_static = "1.4.0"
 

--- a/eif_defs/src/lib.rs
+++ b/eif_defs/src/lib.rs
@@ -49,7 +49,7 @@ pub struct EifHeader {
     /// ramdisks
     pub section_sizes: [u64; MAX_NUM_SECTIONS],
     pub unused: u32,
-    /// crc32 IEEE used for validating the eif file is corect, it contains
+    /// crc32 IEEE used for validating the eif file is correct, it contains
     /// the crc for everything except the bytes representing this field.
     /// Needs to be the last field of the header.
     pub eif_crc32: u32,

--- a/eif_utils/Cargo.toml
+++ b/eif_utils/Cargo.toml
@@ -13,3 +13,4 @@ eif_defs = { path = "../eif_defs" }
 aws-nitro-enclaves-cose = "0.1"
 openssl = "0.10"
 serde_cbor = "0.11"
+serde = { version = ">=1.0", features = ["derive"] }

--- a/src/common/document_errors.rs
+++ b/src/common/document_errors.rs
@@ -65,6 +65,7 @@ lazy_static! {
             (NitroCliErrorEnum::SignalMaskingError, "E54"),
             (NitroCliErrorEnum::SignalUnmaskingError, "E55"),
             (NitroCliErrorEnum::LoggerError, "E56"),
+            (NitroCliErrorEnum::HasherError, "E57"),
         ].iter().cloned().collect();
 }
 
@@ -320,6 +321,9 @@ pub fn get_detailed_info(error_code_str: String, additional_info: &[String]) -> 
         }
         "E56" => {
             ret.push_str("Logger error. Such error appears when attempting to initialize the underlying logging system fails.");
+        }
+        "E57" => {
+            ret.push_str("Hasher error. Such error appears when trying to initialize a hasher or write bytes to it, resulting in a IO error.");
         }
         _ => {
             ret.push_str(format!("No such error code {}", error_code_str).as_str());

--- a/src/common/json_output.rs
+++ b/src/common/json_output.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(clippy::too_many_arguments)]
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -33,6 +34,9 @@ pub struct EnclaveDescribeInfo {
     #[serde(rename = "Flags")]
     /// The bit-mask which provides the enclave's launch flags.
     pub flags: String,
+    #[serde(rename = "PCRs")]
+    /// Contains the PCR values.
+    pub measurements: BTreeMap<String, String>,
 }
 
 impl EnclaveDescribeInfo {
@@ -45,6 +49,7 @@ impl EnclaveDescribeInfo {
         memory_mib: u64,
         state: String,
         flags: String,
+        measurements: BTreeMap<String, String>,
     ) -> Self {
         EnclaveDescribeInfo {
             enclave_id,
@@ -55,6 +60,7 @@ impl EnclaveDescribeInfo {
             memory_mib,
             state,
             flags,
+            measurements,
         }
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -168,6 +168,8 @@ pub enum NitroCliErrorEnum {
     SignalUnmaskingError,
     /// General error for handling logger-related errors.
     LoggerError,
+    /// Hasher operation error
+    HasherError,
 }
 
 impl Default for NitroCliErrorEnum {

--- a/src/enclave_proc/utils.rs
+++ b/src/enclave_proc/utils.rs
@@ -39,7 +39,7 @@ pub fn flags_to_string(flags: u64) -> String {
 pub fn get_enclave_describe_info(
     enclave_manager: &EnclaveManager,
 ) -> NitroCliResult<EnclaveDescribeInfo> {
-    let (slot_uid, enclave_cid, cpus_count, cpu_ids, memory_mib, flags, state) =
+    let (slot_uid, enclave_cid, cpus_count, cpu_ids, memory_mib, flags, state, measurements) =
         enclave_manager.get_description_resources()?;
     let info = EnclaveDescribeInfo::new(
         generate_enclave_id(slot_uid)?,
@@ -49,6 +49,7 @@ pub fn get_enclave_describe_info(
         memory_mib,
         state.to_string(),
         flags_to_string(flags),
+        measurements,
     );
     Ok(info)
 }

--- a/src/enclave_proc/utils.rs
+++ b/src/enclave_proc/utils.rs
@@ -39,7 +39,7 @@ pub fn flags_to_string(flags: u64) -> String {
 pub fn get_enclave_describe_info(
     enclave_manager: &EnclaveManager,
 ) -> NitroCliResult<EnclaveDescribeInfo> {
-    let (slot_uid, enclave_cid, cpus_count, cpu_ids, memory_mib, flags, state, measurements) =
+    let (slot_uid, enclave_cid, cpus_count, cpu_ids, memory_mib, flags, state) =
         enclave_manager.get_description_resources()?;
     let info = EnclaveDescribeInfo::new(
         generate_enclave_id(slot_uid)?,
@@ -49,7 +49,6 @@ pub fn get_enclave_describe_info(
         memory_mib,
         state.to_string(),
         flags_to_string(flags),
-        measurements,
     );
     Ok(info)
 }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -129,7 +129,17 @@ def describe_enclaves_ok():
 
         return run_subprocess_ok(args)
 
-# Connects to the enclave console defined by the enclave id with an optional disconnect timeout
+# Runs describe_eif command, describing the EIF at the given path
+# Checks if command is successful and returns a CompletedProcess
+def describe_eif_ok(eif_name):
+        eif_path = TEST_IMAGES + eif_name
+        args = [ "nitro-cli",
+                 "describe-eif",
+                 "--eif-path", eif_path,
+                ]
+        return run_subprocess_ok(args)
+
+# Connects to the enclave console defined by the enclave id
 # Returns the handle to the running process.
 def connect_console(enclave_id, timeout = None):
         args = ["nitro-cli",

--- a/tests/integration/test_commands.py
+++ b/tests/integration/test_commands.py
@@ -121,3 +121,25 @@ def test_describe_enclaves(init_resources):
         result = describe_enclaves_ok()
         result_json = json.loads(result.stdout.decode('UTF-8'))
         assert not result_json
+
+# Test describe_eif command is successful and returns as expected
+def test_describe_eif(init_resources):
+        result = run_enclave_ok(SAMPLE_EIF, "1028", "2")
+        result_json = json.loads(result.stdout.decode('UTF-8'))
+        enclave_id = result_json["EnclaveID"]
+
+        result = describe_enclaves_ok()
+        result_json = json.loads(result.stdout.decode('UTF-8'))
+        run_measurements = result_json[0]["Measurements"]
+
+        terminate_enclave_ok(enclave_id)
+
+        result = describe_eif_ok(SAMPLE_EIF)
+        result_json = json.loads(result.stdout.decode('UTF-8'))
+        static_measurements = result_json["Measurements"]
+
+        assert static_measurements["HashAlgorithm"] == run_measurements["HashAlgorithm"]
+        assert static_measurements["PCR0"] == run_measurements["PCR0"]
+        assert static_measurements["PCR1"] == run_measurements["PCR1"]
+        assert static_measurements["PCR2"] == run_measurements["PCR2"]
+        assert not result_json["IsSigned"]

--- a/tests/test_nitro_cli_args.rs
+++ b/tests/test_nitro_cli_args.rs
@@ -59,6 +59,22 @@ mod test_nitro_cli_args {
     }
 
     #[test]
+    fn describe_eif_correct_command() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "describe-eif", "--eif-path", "dir/image.eif"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), false)
+    }
+
+    #[test]
+    fn describe_eif_without_path_arg() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "describe-eif", "--eif-path"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
     fn console_without_enclave_id_arg_is_required() {
         let app = create_app!();
         let args = vec!["nitro cli", "console"];


### PR DESCRIPTION
## 1. PCR values at 'describe-enclave'

PCRs are now computed when running the enclave not only when building the EIF. The values are saved in the EnclaveManager and printed when executing describe-enclaves.
Computation is done by a thread spawned when starting the enclave and completed by waiting the thread when calling the first describe.

Previous output format:
```
$ ./nitro-cli run-enclave --cpu-count 2 --memory 256 --enclave-cid 16 --eif-path hello-signed.eif --debug-mode
Start allocating memory...
Started enclave with enclave-cid: 16, memory: 256 MiB, cpu-ids: [2, 10]
{
  "EnclaveID": "i-0584873aac8fea23b-enc17ad2edcbfdad4b",
  "ProcessID": 95271,
  "EnclaveCID": 16,
  "NumberOfCPUs": 2,
  "CPUIDs": [
    2,
    10
  ],
  "MemoryMiB": 256
}
ubuntu@ip-172-31-46-66:~/aws-nitro-enclaves-cli/target/release$ ./nitro-cli describe-enclaves
[
  {
    "EnclaveID": "i-0584873aac8fea23b-enc17ad2edcbfdad4b",
    "ProcessID": 95271,
    "EnclaveCID": 16,
    "NumberOfCPUs": 2,
    "CPUIDs": [
      2,
      10
    ],
    "MemoryMiB": 256,
    "State": "RUNNING",
    "Flags": "DEBUG_MODE"
  }
]
```


New output format:
```
$ ./nitro-cli run-enclave --cpu-count 2 --memory 256 --enclave-cid 16 --eif-path hello-signed.eif --debug-mode
Start allocating memory...
Started enclave with enclave-cid: 16, memory: 256 MiB, cpu-ids: [2, 10]
{
  "EnclaveID": "i-0584873aac8fea23b-enc17ad2edcbfdad4b",
  "ProcessID": 95271,
  "EnclaveCID": 16,
  "NumberOfCPUs": 2,
  "CPUIDs": [
    2,
    10
  ],
  "MemoryMiB": 256
}
ubuntu@ip-172-31-46-66:~/aws-nitro-enclaves-cli/target/release$ ./nitro-cli describe-enclaves
[
  {
    "EnclaveID": "i-0584873aac8fea23b-enc17b31c3b2a6b1b2",
    "ProcessID": 26719,
    "EnclaveCID": 16,
    "NumberOfCPUs": 2,
    "CPUIDs": [
      1,
      9
    ],
    "MemoryMiB": 256,
    "State": "RUNNING",
    "Flags": "NONE",
    "Measurements": {
      "HashAlgorithm": "Sha384 { ... }",
      "PCR0": "f1ec3aed44f8795b1331d863918ab7a5e606fa238782b8317c4a47c1edbc16fd1a74b7d78a7aff37cea3b11870b85c6f",
      "PCR1": "aca6e62ffbf5f7deccac452d7f8cee1b94048faf62afc16c8ab68c9fed8c38010c73a669f9a36e596032f0b973d21895",
      "PCR2": "aa64ebcf9f8ec26838bade833b6dc47f145123b1ac56ba6b8990104ebf3d6b1a133e30c31a1560c37f1763502696320d",
      "PCR8": "7f62d23e1fda5040775415a76cc5a1b4ed462e25f27244f741abc3c0b4a3703baa067c6b7d6dbe0f4ff80506c8ff47d0"
    }
  }
]

```

## 2. NitroCLI command: describe-if

New command implemented for displaying information about an EIF at a given path. Sections of the file are parsed and formatted as JSON. The output contains information about the EIF version, PCRs, signing certificate and in future development will include metadata. Usage example:

```
$ ./nitro-cli describe-eif --eif-path hello-signed.eif
{
  "EifVersion": 3,
  "Measurements": {
    "HashAlgorithm": "Sha384 { ... }",
    "PCR0": "f1ec3aed44f8795b1331d863918ab7a5e606fa238782b8317c4a47c1edbc16fd1a74b7d78a7aff37cea3b11870b85c6f",
    "PCR1": "aca6e62ffbf5f7deccac452d7f8cee1b94048faf62afc16c8ab68c9fed8c38010c73a669f9a36e596032f0b973d21895",
    "PCR2": "aa64ebcf9f8ec26838bade833b6dc47f145123b1ac56ba6b8990104ebf3d6b1a133e30c31a1560c37f1763502696320d",
    "PCR8": "7f62d23e1fda5040775415a76cc5a1b4ed462e25f27244f741abc3c0b4a3703baa067c6b7d6dbe0f4ff80506c8ff47d0"
  },
  "IsSigned": true,
  "SigningCertificate": {
    "IssuerName": {
      "commonName": "AWS",
      "countryName": "US",
      "localityName": "Seattle",
      "organizationName": "Amazon",
      "organizationalUnitName": "AWS",
      "stateOrProvinceName": "WA"
    },
    "Algorithm": "ecdsa-with-SHA384",
    "NotBefore": "Jul 30 12:26:57 2021 GMT",
    "NotAfter": "Aug 19 12:26:57 2021 GMT",
    "Signature": "30:65:02:30:0B:15:D6:95:5A:3D:C0:45:37:BF:2C:20:68:58:43:AA:17:DA:6F:8D:B1:97:E2:ED:7F:02:1C:C5:14:12:2D:1B:91:2C:95:D2:6A:DB:C2:FB:74:36:E1:57:7A:A5:FC:30:02:31:00:C7:E8:50:95:63:EA:42:A1:8D:6E:2A:5F:9B:A0:A8:87:30:A0:9E:14:8D:63:E6:98:25:E0:3B:F9:4E:74:FE:80:C4:59:4D:08:F0:77:C2:4A:8B:73:5C:41:95:C4:B7:4C"
  }
}
```

## Performance measurement

**Without PCR computing:**

```
$ time ./nitro-cli run-enclave --cpu-count 2 --memory 16000 --enclave-cid 16 --eif-path ~/aws-nitro-enclaves-cli/target/release/large.eif
Start allocating memory...
Started enclave with enclave-cid: 16, memory: 16000 MiB, cpu-ids: [1, 9]
{
  "EnclaveID": "i-0584873aac8fea23b-enc17b30487ec792eb",
  "ProcessID": 22596,
  "EnclaveCID": 16,
  "NumberOfCPUs": 2,
  "CPUIDs": [
    1,
    9
  ],
  "MemoryMiB": 16000
}

real	0m53.978s
user	0m0.003s
sys	0m0.000s

```
**Spawn thread that computes PCRs and describe**

```
$ time ./nitro-cli run-enclave --cpu-count 2 --memory 16000 --enclave-cid 16 --eif-path large.eif && time ./nitro-cli describe-enclaves
Start allocating memory...
Started enclave with enclave-cid: 16, memory: 16000 MiB, cpu-ids: [1, 9]
{
  "EnclaveID": "i-0584873aac8fea23b-enc17b304b1748a5f5",
  "ProcessID": 22632,
  "EnclaveCID": 16,
  "NumberOfCPUs": 2,
  "CPUIDs": [
    1,
    9
  ],
  "MemoryMiB": 16000
}

real	0m53.943s
user	0m0.003s
sys	0m0.000s
[
  {
    "EnclaveID": "i-0584873aac8fea23b-enc17b304b1748a5f5",
    "ProcessID": 22632,
    "EnclaveCID": 16,
    "NumberOfCPUs": 2,
    "CPUIDs": [
      1,
      9
    ],
    "MemoryMiB": 16000,
    "State": "RUNNING",
    "Flags": "NONE",
    "Measurements": {
      "HashAlgorithm": "Sha384 { ... }",
      "PCR0": "6e6ae70d875826e565fae50e2ec71396c9f092b0f7cfd9817efb6a714c9ca92e06c8a1c1c507d4e3895659f93ff62294",
      "PCR1": "aca6e62ffbf5f7deccac452d7f8cee1b94048faf62afc16c8ab68c9fed8c38010c73a669f9a36e596032f0b973d21895",
      "PCR2": "ac0d83a3bf5707cd519c44bd82c93d0c4de772233caa850889cc60dc018649272b90a9bbcad0d584183a74f23b719e33"
    }
  }
]

real	0m0.003s
user	0m0.002s
sys	0m0.000s
```



**Describe EIF -> same operation done by the previous thread**

```
$ time ./nitro-cli describe-eif --eif-path large.eif
{
  "EifVersion": 3,
  "Measurements": {
    "HashAlgorithm": "Sha384 { ... }",
    "PCR0": "6e6ae70d875826e565fae50e2ec71396c9f092b0f7cfd9817efb6a714c9ca92e06c8a1c1c507d4e3895659f93ff62294",
    "PCR1": "aca6e62ffbf5f7deccac452d7f8cee1b94048faf62afc16c8ab68c9fed8c38010c73a669f9a36e596032f0b973d21895",
    "PCR2": "ac0d83a3bf5707cd519c44bd82c93d0c4de772233caa850889cc60dc018649272b90a9bbcad0d584183a74f23b719e33"
  },
  "IsSigned": false
}

real	0m21.681s
user	0m19.708s
sys	0m1.972s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
