### PR TITLE
Add `--disconnect-timeout` option to console subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "tempfile",
+ "vmm-sys-util",
  "vsock",
 ]
 
@@ -1672,6 +1673,16 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cf11afbc4ebc0d5c7a7748a77d19e2042677fc15faa2f4ccccb27c18a60605"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ eif_loader = { path = "./eif_loader" }
 enclave_build = { path = "./enclave_build" }
 openssl = "0.10"
 vsock = "0.1.5"
+vmm-sys-util = "0.8.0"
 
 lazy_static = "1.4.0"
 

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -4787,6 +4787,8 @@ limitations under the License.
                     
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.3</a></li>
                     
+                    <li><a href=" https://github.com/rust-vmm/vmm-sys-util ">vmm-sys-util 0.8.0</a></li>
+                    
                     <li><a href=" https://github.com/fsyncd/vsock-rs ">vsock 0.1.5</a></li>
                     
                 </ul>

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -163,6 +163,8 @@ impl TerminateEnclavesArgs {
 pub struct ConsoleArgs {
     /// The ID of the enclave whose console is to be shown.
     pub enclave_id: String,
+    /// The time in seconds after the console disconnects from the enclave.
+    pub disconnect_timeout_sec: Option<u64>,
 }
 
 impl ConsoleArgs {
@@ -171,6 +173,8 @@ impl ConsoleArgs {
         Ok(ConsoleArgs {
             enclave_id: parse_enclave_id(args)
                 .map_err(|e| e.add_subaction("Parse enclave ID".to_string()))?,
+            disconnect_timeout_sec: parse_disconnect_timeout(args)
+                .map_err(|e| e.add_subaction("Parse disconnect timeout".to_string()))?,
         })
     }
 }
@@ -315,6 +319,24 @@ fn parse_enclave_id(args: &ArgMatches) -> NitroCliResult<String> {
         )
     })?;
     Ok(enclave_id.to_string())
+}
+
+/// Parse the disconnect timeout from the command-line arguments.
+fn parse_disconnect_timeout(args: &ArgMatches) -> NitroCliResult<Option<u64>> {
+    let disconnect_timeout = match args.value_of("disconnect-timeout") {
+        Some(arg) => Some(arg.parse::<u64>().map_err(|_| {
+            new_nitro_cli_failure!(
+                "`disconnect-timeout` argument can't be parsed as a number",
+                NitroCliErrorEnum::InvalidArgument
+            )
+            .add_info(vec![
+                "disconnect-timeout",
+                args.value_of("disconnect-timeout").unwrap(),
+            ])
+        })?),
+        None => None,
+    };
+    Ok(disconnect_timeout)
 }
 
 /// Parse the list of requested CPU IDs from the command-line arguments.

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,8 @@ fn main() {
                 })
                 .ok_or_exit_with_errno(None);
             }
-            console_enclaves(enclave_cid)
+
+            console_enclaves(enclave_cid, console_args.disconnect_timeout_sec)
                 .map_err(|e| {
                     e.add_subaction("Failed to connect to enclave console".to_string())
                         .set_action(ENCLAVE_CONSOLE_STR.to_string())

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -129,12 +129,15 @@ def describe_enclaves_ok():
 
         return run_subprocess_ok(args)
 
-# Connects to the enclave console defined by the enclave id
+# Connects to the enclave console defined by the enclave id with an optional disconnect timeout
 # Returns the handle to the running process.
-def connect_console(enclave_id):
+def connect_console(enclave_id, timeout = None):
         args = ["nitro-cli",
                 "console",
                 "--enclave-id", enclave_id]
+
+        if timeout is not None:
+                args.extend(["--disconnect-timeout", str(timeout)])
 
         return subprocess.Popen(args, stdout = PIPE, stderr = PIPE)
 

--- a/tests/test_nitro_cli_args.rs
+++ b/tests/test_nitro_cli_args.rs
@@ -97,6 +97,35 @@ mod test_nitro_cli_args {
     }
 
     #[test]
+    fn console_correct_disconnect_timeout_command() {
+        let app = create_app!();
+        let args = vec![
+            "nitro cli",
+            "console",
+            "--enclave-id",
+            "i-1234_enc123",
+            "--disconnect-timeout",
+            "10",
+        ];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), false)
+    }
+
+    #[test]
+    fn console_disconnect_timeout_takes_value() {
+        let app = create_app!();
+        let args = vec![
+            "nitro cli",
+            "console",
+            "--enclave-id",
+            "i-1234_enc123",
+            "--disconnect-timeout",
+        ];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
     fn build_enclave_docker_uri_arg_is_required() {
         let app = create_app!();
         let args = vec!["nitro cli", "build-enclave", "--output-file", "image.eif"];

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -473,7 +473,7 @@ mod tests {
         let replies: Vec<EnclaveDescribeInfo> = vec![info];
         let _reply = &replies[0];
 
-        assert_eq!(enclave_console(enclave_cid).is_err(), true);
+        assert_eq!(enclave_console(enclave_cid, None).is_err(), true);
 
         terminate_enclaves(&mut enclave_manager, None).expect("Terminate enclaves failed");
     }


### PR DESCRIPTION
*Issue #, if available:*
Resolves #229

*Description of changes:*
Add `--disconnect-timeout` option to console subcommand.
Add cli argument tests and integration tests for the `--disconnect-timeout` option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
