### PR TITLE
tools: Ignore unsolved cargo audit vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13988670860b076248c74e1b54444efc4f1dec70c8bb25da4b7c0024396b72bf"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.3.19",
  "winapi",
 ]
 
@@ -606,15 +606,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -633,9 +633,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -646,8 +646,8 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
- "socket2",
+ "pin-project-lite",
+ "socket2 0.4.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -846,7 +846,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi",
 ]
 
@@ -1420,6 +1420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ nitro-audit: build-setup build-container
 		-v "$$(readlink -f ${OBJ_PATH})":/nitro_build \
 		$(CONTAINER_TAG) bin/bash -c \
 			'source /root/.cargo/env && \
-			cargo audit -f /nitro_src/Cargo.lock'
+			cargo audit -f /nitro_src/Cargo.lock --ignore RUSTSEC-2021-0080'
 
 nitro-about: build-setup build-container
 	$(DOCKER) run \

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -95,7 +95,7 @@
                     
                     <li><a href=" https://github.com/hermitcore/rusty-hermit ">hermit-abi 0.1.10</a></li>
                     
-                    <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.3.4</a></li>
+                    <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.4.1</a></li>
                     
                     <li><a href=" https://github.com/sfackler/hyper-openssl ">hyper-openssl 0.9.1</a></li>
                     
@@ -178,6 +178,8 @@
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.6.1</a></li>
                     
                     <li><a href=" https://github.com/alexcrichton/socket2-rs ">socket2 0.3.19</a></li>
+                    
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.4.1</a></li>
                     
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.60</a></li>
                     
@@ -2817,7 +2819,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     
-                    <li><a href=" https://github.com/pyfisch/httpdate ">httpdate 0.3.2</a></li>
+                    <li><a href=" https://github.com/pyfisch/httpdate ">httpdate 1.0.1</a></li>
                     
                 </ul>
                 <pre class="license-text">Apache License
@@ -3339,7 +3341,7 @@ limitations under the License.
                     
                     <li><a href=" https://github.com/alexheretic/linked-hash-set ">linked_hash_set 0.1.3</a></li>
                     
-                    <li><a href=" https://github.com/retep998/winapi-rs ">winapi 0.3.8</a></li>
+                    <li><a href=" https://github.com/retep998/winapi-rs ">winapi 0.3.9</a></li>
                     
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -5903,10 +5905,10 @@ DEALINGS IN THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.4</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.11</a></li>
                     
                 </ul>
-                <pre class="license-text">Copyright (c) 2014-2018 Sean McArthur
+                <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -5925,7 +5927,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
 </pre>
             </li>
             


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Modify nitro-audit Makefile rule so that it ignores RUSTSEC-2021-0080 vulnerability
* Update cargo packages

Signed-off-by: Costin-Robert Sin <costisin@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
