### PR TITLE
nitro-cli: Update version of tar crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,13 +1454,12 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.26"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
+checksum = "8190d9cdacf6ee1b080605fd719b58d80a9fcbcea64db6744b26f743da02e447"
 dependencies = [
  "filetime",
  "libc",
- "redox_syscall 0.1.56",
  "xattr",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ nitro-audit: build-setup build-container
 		-v "$$(readlink -f ${OBJ_PATH})":/nitro_build \
 		$(CONTAINER_TAG) bin/bash -c \
 			'source /root/.cargo/env && \
-			cargo audit -f /nitro_src/Cargo.lock --ignore RUSTSEC-2021-0080'
+			cargo audit -f /nitro_src/Cargo.lock'
 
 nitro-about: build-setup build-container
 	$(DOCKER) run \

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -183,7 +183,7 @@
                     
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.60</a></li>
                     
-                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.26</a></li>
+                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.36</a></li>
                     
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.1.0</a></li>
                     


### PR DESCRIPTION
Fix the following error by updating to the latest version of the tar
crate:

Crate:         tar
Version:       0.4.26
Title:         Links in archive can create arbitrary directories
Date:          2021-07-19
ID:            RUSTSEC-2021-0080
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0080
Solution:      Upgrade to >=0.4.36
Dependency tree:
tar 0.4.26
└── shiplift 0.7.0
    └── enclave_build 0.1.0
        └── nitro-cli 1.0.12

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
