### PR TITLE
nitro-cli: Set correct group ownership for /dev/nitro_enclaves

### DIFF
--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -112,6 +112,7 @@ systemd-tmpfiles --create /usr/lib/tmpfiles.d/%{ne_name}.conf
 echo "KERNEL==\"nitro_enclaves\", SUBSYSTEM==\"misc\", OWNER=\"root\", GROUP=\""%{ne_group}"\", \
     MODE=\"0660\", TAG+=\"systemd\"" > /usr/lib/udev/rules.d/99-nitro_enclaves.rules
 udevadm trigger -y nitro_enclaves
+chgrp %{ne_group} /dev/%{ne_name}
 
 echo -e "
     * In order to successfully run Nitro Enclaves, please add your user to group '"%{ne_group}"'"
@@ -165,6 +166,7 @@ if [ $1 -eq 2 ]; then
     echo "KERNEL==\"nitro_enclaves\", SUBSYSTEM==\"misc\", OWNER=\"root\", GROUP=\""%{ne_group}"\", \
         MODE=\"0660\", TAG+=\"systemd\"" > /usr/lib/udev/rules.d/99-nitro_enclaves.rules
     udevadm trigger -y nitro_enclaves
+    chgrp %{ne_group} /dev/%{ne_name}
 fi
 
 

--- a/bootstrap/nitro-cli-config
+++ b/bootstrap/nitro-cli-config
@@ -481,6 +481,7 @@ function driver_insert {
     # Trigger the udev rule.
     sudo_run "udevadm control --reload"
     sudo_run "udevadm trigger /dev/$DRIVER_NAME" || fail "Could not apply the NE udev rule."
+    sudo_run "chgrp $NE_GROUP_NAME /dev/$DRIVER_NAME" || fail "Could not change the group owner of the NE misc device file."
 
     # The previous operation may need some time to complete.
     while [ "$NE_GROUP_NAME" != "$(stat -c '%G' /dev/$DRIVER_NAME)" ] && [ "$loop_idx" -lt 3 ]; do


### PR DESCRIPTION
This fixes https://github.com/aws/aws-nitro-enclaves-cli/issues/227.

The correct ownership of the "/dev/nitro_enclaves" file should be
root:ne. This ownership change may not occur immediately upon
triggering the udev rule is, effectively preventing a non-root user
from interacting with enclaves until either the change occurs or
the instance gets rebooted. Therefore, we use 'chgrp' to force the
correct group ownership change from the start.

Signed-off-by: Andrei Trandafir <aatrand@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
