### PR TITLE
eif_defs: Add new metadata EIF section type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_json",
  "sha2",
 ]
 

--- a/eif_defs/Cargo.toml
+++ b/eif_defs/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 sha2 = "0.9.5"
 serde = { version = ">=1.0", features = ["derive"] }
+serde_json = "1.0"
 num-traits = "0.2"
 num-derive = "0.3"
 byteorder = "1.3"

--- a/eif_utils/src/lib.rs
+++ b/eif_utils/src/lib.rs
@@ -337,7 +337,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
 
         kernel_file
             .seek(SeekFrom::Start(0))
-            .expect("Could not seek kernel to begining");
+            .expect("Could not seek kernel to beginning");
         let mut buffer = Vec::new();
         kernel_file
             .read_to_end(&mut buffer)
@@ -472,7 +472,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
 
             ramdisk
                 .seek(SeekFrom::Start(0))
-                .expect("Could not seek ramdisk to begining");
+                .expect("Could not seek ramdisk to beginning");
             let mut buffer = Vec::new();
             ramdisk
                 .read_to_end(&mut buffer)
@@ -532,7 +532,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
         let mut kernel_file = &self.kernel;
         kernel_file
             .seek(SeekFrom::Start(0))
-            .expect("Could not seek kernel to begining");
+            .expect("Could not seek kernel to beginning");
         let mut buffer = Vec::new();
         kernel_file
             .read_to_end(&mut buffer)
@@ -546,7 +546,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
         for (index, mut ramdisk) in (&self.ramdisks).iter().enumerate() {
             ramdisk
                 .seek(SeekFrom::Start(0))
-                .expect("Could not seek kernel to begining");
+                .expect("Could not seek kernel to beginning");
             let mut buffer = Vec::new();
             ramdisk
                 .read_to_end(&mut buffer)
@@ -593,7 +593,7 @@ pub struct SignCertificateInfo {
 }
 
 impl SignCertificateInfo {
-    /// Create new signing ceritificate information structure
+    /// Create new signing certificate information structure
     pub fn new(
         issuer_name: BTreeMap<String, String>,
         algorithm: String,
@@ -719,13 +719,13 @@ impl EifReader {
                     let cert = openssl::x509::X509::from_pem(&des_sign[0].signing_certificate)
                         .map_err(|e| format!("Error while digesting certificate: {:?}", e))?;
                     let cert_der = cert.to_der().map_err(|e| {
-                        format!("Failed to deserialize sigining certificate: {:?}", e)
+                        format!("Failed to deserialize signing certificate: {:?}", e)
                     })?;
                     cert_hasher.write_all(&cert_der).map_err(|e| {
                         format!("Failed to write signature section to cert_hasher: {:?}", e)
                     })?;
                 }
-                EifSectionType::EifSectionInvalid => {
+                EifSectionType::EifSectionInvalid | EifSectionType::EifSectionMetadata => {
                     return Err("Eif contains an invalid section".to_string());
                 }
             }


### PR DESCRIPTION
Added EifSectionMetadata to the EifSectionType enum. The
purpose is to use it in eVMM to update the EIF version.
V4 will contain the metadata section added the with the
`build-enclaves` command.

Also added Metadata struct for (de)serializing the EIF section
in eVMM. Currently treating EifSectionMetadata as an invalid
section in EifReader until we merge the rest of the metadata
implementation.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
