### PR TITLE
Add support for aarch64 rpm with koji

### DIFF
--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -22,7 +22,8 @@ Release:    0%{?dist}
 
 License:    Apache 2.0
 
-BuildArch: x86_64
+BuildArch: noarch
+ExclusiveArch: x86_64, aarch64
 
 Source0: aws-nitro-enclaves-cli.tar.gz
 Source1: nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
    Since the spec file doesn't support a list for the BuildArch
    tag, set it as noarch, as if the build it's supported by any
    architecture. Limit the build architectures with the ExclusiveArch tag.

    More details here: [](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_spec_files)

Signed-off-by: George-Aurelian Popescu <popegeo@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
