### PR TITLE
Remove BuildArch from spec file

### DIFF
--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -22,7 +22,6 @@ Release:    0%{?dist}
 
 License:    Apache 2.0
 
-BuildArch: noarch
 ExclusiveArch: x86_64, aarch64
 
 Source0: aws-nitro-enclaves-cli.tar.gz


### PR DESCRIPTION
If the BuildArch tag is not set, the package automatically
inherits the Architecture of the machine on which is built.

Signed-off-by: popegeo <popegeo@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
