### PR TITLE
Correct typo in ExclusiveArch tag

### DIFF
--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -22,7 +22,7 @@ Release:    0%{?dist}
 
 License:    Apache 2.0
 
-ExclusiveArch: x86_64, aarch64
+ExclusiveArch: x86_64 aarch64
 
 Source0: aws-nitro-enclaves-cli.tar.gz
 Source1: nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
The ExclusiveArch tag doesn't support "," between architectures.

Signed-off-by: popegeo <popegeo@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
