### PR TITLE
Named enclaves

### DIFF
--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -28,6 +28,8 @@ pub struct RunEnclavesArgs {
     pub debug_mode: Option<bool>,
     /// The number of CPUs that the enclave will receive.
     pub cpu_count: Option<u32>,
+    /// Enclave name set by the user.
+    pub enclave_name: Option<String>,
 }
 
 impl RunEnclavesArgs {
@@ -75,6 +77,8 @@ impl RunEnclavesArgs {
                 cpu_ids: parse_cpu_ids(args)
                     .map_err(|err| err.add_subaction("Parse CPU IDs".to_string()))?,
                 debug_mode: debug_mode(args),
+                enclave_name: parse_enclave_name(args)
+                    .map_err(|err| err.add_subaction("Parse enclave name".to_string()))?,
             })
         }
     }
@@ -390,6 +394,11 @@ fn debug_mode(args: &ArgMatches) -> Option<bool> {
     } else {
         None
     }
+}
+
+/// Parse the enclave name from the command-line arguments.
+fn parse_enclave_name(args: &ArgMatches) -> NitroCliResult<Option<String>> {
+    Ok(args.value_of("enclave-name").map(|e| e.to_string()))
 }
 
 fn parse_signing_certificate(args: &ArgMatches) -> Option<String> {

--- a/src/common/document_errors.rs
+++ b/src/common/document_errors.rs
@@ -66,6 +66,7 @@ lazy_static! {
             (NitroCliErrorEnum::SignalUnmaskingError, "E55"),
             (NitroCliErrorEnum::LoggerError, "E56"),
             (NitroCliErrorEnum::HasherError, "E57"),
+            (NitroCliErrorEnum::EnclaveNamingError, "E58"),
         ].iter().cloned().collect();
 }
 
@@ -324,6 +325,9 @@ pub fn get_detailed_info(error_code_str: String, additional_info: &[String]) -> 
         }
         "E57" => {
             ret.push_str("Hasher error. Such error appears when trying to initialize a hasher or write bytes to it, resulting in a IO error.");
+        }
+        "E58" => {
+            ret.push_str("Naming error. Such error appears when trying to perform an enclave operation using the enclave name and the name is invalid.");
         }
         _ => {
             ret.push_str(format!("No such error code {}", error_code_str).as_str());

--- a/src/common/json_output.rs
+++ b/src/common/json_output.rs
@@ -65,19 +65,28 @@ impl EnclaveDescribeInfo {
 /// like measurements, not found in older NitroCLI versions
 #[derive(Clone, Serialize, Deserialize)]
 pub struct DescribeOutput {
+    /// Enclave name assigned by the user
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "EnclaveName")]
+    pub enclave_name: Option<String>,
     #[serde(flatten)]
     /// General describe info found in all versions of NitroCLI
     describe_info: EnclaveDescribeInfo,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(flatten)]
     /// Build measurements containing PCRs
-    build_info: Option<EnclaveBuildInfo>,
+    pub build_info: Option<EnclaveBuildInfo>,
 }
 
 impl DescribeOutput {
     /// Creates new describe output from available
-    pub fn new(describe_info: EnclaveDescribeInfo, build_info: Option<EnclaveBuildInfo>) -> Self {
+    pub fn new(
+        enclave_name: Option<String>,
+        describe_info: EnclaveDescribeInfo,
+        build_info: Option<EnclaveBuildInfo>,
+    ) -> Self {
         DescribeOutput {
+            enclave_name,
             describe_info,
             build_info,
         }
@@ -87,6 +96,9 @@ impl DescribeOutput {
 /// The information to be provided for a `run-enclave` request.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct EnclaveRunInfo {
+    #[serde(rename = "EnclaveName")]
+    /// The name of the enclave.
+    pub enclave_name: String,
     #[serde(rename = "EnclaveID")]
     /// The full ID of the enclave.
     pub enclave_id: String,
@@ -110,6 +122,7 @@ pub struct EnclaveRunInfo {
 impl EnclaveRunInfo {
     /// Create a new `EnclaveRunInfo` instance from the given enclave information.
     pub fn new(
+        enclave_name: String,
         enclave_id: String,
         enclave_cid: u64,
         cpu_count: usize,
@@ -117,6 +130,7 @@ impl EnclaveRunInfo {
         memory_mib: u64,
     ) -> Self {
         EnclaveRunInfo {
+            enclave_name,
             enclave_id,
             process_id: std::process::id(),
             enclave_cid,
@@ -130,6 +144,10 @@ impl EnclaveRunInfo {
 /// The information to be provided for a `terminate-enclave` request.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct EnclaveTerminateInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "EnclaveName")]
+    /// The name of the enclave. Optional for older versions.
+    pub enclave_name: Option<String>,
     #[serde(rename = "EnclaveID")]
     /// The full ID of the enclave.
     pub enclave_id: String,
@@ -140,8 +158,9 @@ pub struct EnclaveTerminateInfo {
 
 impl EnclaveTerminateInfo {
     /// Create a new `EnclaveTerminateInfo` instance from the given enclave information.
-    pub fn new(enclave_id: String, terminated: bool) -> Self {
+    pub fn new(enclave_name: Option<String>, enclave_id: String, terminated: bool) -> Self {
         EnclaveTerminateInfo {
+            enclave_name,
             enclave_id,
             terminated,
         }

--- a/src/common/json_output.rs
+++ b/src/common/json_output.rs
@@ -11,6 +11,10 @@ use std::collections::BTreeMap;
 /// The information to be provided for a `describe-enclaves` request.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct EnclaveDescribeInfo {
+    /// Enclave name assigned by the user
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "EnclaveName")]
+    pub enclave_name: Option<String>,
     #[serde(rename = "EnclaveID")]
     /// The full ID of the enclave.
     pub enclave_id: String,
@@ -35,11 +39,16 @@ pub struct EnclaveDescribeInfo {
     #[serde(rename = "Flags")]
     /// The bit-mask which provides the enclave's launch flags.
     pub flags: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(flatten)]
+    /// Build measurements containing PCRs
+    pub build_info: Option<EnclaveBuildInfo>,
 }
 
 impl EnclaveDescribeInfo {
     /// Create a new `EnclaveDescribeInfo` instance from the given enclave information.
     pub fn new(
+        enclave_name: Option<String>,
         enclave_id: String,
         enclave_cid: u64,
         cpu_count: u64,
@@ -47,8 +56,10 @@ impl EnclaveDescribeInfo {
         memory_mib: u64,
         state: String,
         flags: String,
+        build_info: Option<EnclaveBuildInfo>,
     ) -> Self {
         EnclaveDescribeInfo {
+            enclave_name,
             enclave_id,
             process_id: std::process::id(),
             enclave_cid,
@@ -57,37 +68,6 @@ impl EnclaveDescribeInfo {
             memory_mib,
             state,
             flags,
-        }
-    }
-}
-
-/// Output structure for describe command containing additional fields,
-/// like measurements, not found in older NitroCLI versions
-#[derive(Clone, Serialize, Deserialize)]
-pub struct DescribeOutput {
-    /// Enclave name assigned by the user
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "EnclaveName")]
-    pub enclave_name: Option<String>,
-    #[serde(flatten)]
-    /// General describe info found in all versions of NitroCLI
-    describe_info: EnclaveDescribeInfo,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(flatten)]
-    /// Build measurements containing PCRs
-    pub build_info: Option<EnclaveBuildInfo>,
-}
-
-impl DescribeOutput {
-    /// Creates new describe output from available
-    pub fn new(
-        enclave_name: Option<String>,
-        describe_info: EnclaveDescribeInfo,
-        build_info: Option<EnclaveBuildInfo>,
-    ) -> Self {
-        DescribeOutput {
-            enclave_name,
-            describe_info,
             build_info,
         }
     }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -195,6 +195,8 @@ pub enum EnclaveProcessCommandType {
     GetEnclaveCID,
     /// Request an enclave's flags (sent by the CLI).
     GetEnclaveFlags,
+    /// Request an enclave's name (sent by the CLI).
+    GetEnclaveName,
     /// Notify the socket connection listener to shut down (sent by the enclave process to itself).
     ConnectionListenerStop,
     /// Do not execute a command due to insufficient privileges (sent by the CLI, modified by the enclave process).

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -170,6 +170,8 @@ pub enum NitroCliErrorEnum {
     LoggerError,
     /// Hasher operation error
     HasherError,
+    /// Enclave naming error
+    EnclaveNamingError,
 }
 
 impl Default for NitroCliErrorEnum {
@@ -197,6 +199,8 @@ pub enum EnclaveProcessCommandType {
     GetEnclaveFlags,
     /// Request an enclave's name (sent by the CLI).
     GetEnclaveName,
+    /// Request the ID of an enclave only if the name matches (sent by the CLI).
+    GetIDbyName,
     /// Notify the socket connection listener to shut down (sent by the enclave process to itself).
     ConnectionListenerStop,
     /// Do not execute a command due to insufficient privileges (sent by the CLI, modified by the enclave process).

--- a/src/enclave_proc/connection.rs
+++ b/src/enclave_proc/connection.rs
@@ -85,6 +85,7 @@ impl CommandRequesterPolicy {
             EnclaveProcessCommandType::GetEnclaveCID,
             EnclaveProcessCommandType::GetEnclaveFlags,
             EnclaveProcessCommandType::GetEnclaveName,
+            EnclaveProcessCommandType::GetIDbyName,
             EnclaveProcessCommandType::ConnectionListenerStop,
         ];
         let cmds_read_only = vec![
@@ -92,6 +93,7 @@ impl CommandRequesterPolicy {
             EnclaveProcessCommandType::GetEnclaveCID,
             EnclaveProcessCommandType::GetEnclaveFlags,
             EnclaveProcessCommandType::GetEnclaveName,
+            EnclaveProcessCommandType::GetIDbyName,
         ];
         let mut policy = HashMap::new();
 

--- a/src/enclave_proc/connection.rs
+++ b/src/enclave_proc/connection.rs
@@ -84,12 +84,14 @@ impl CommandRequesterPolicy {
             EnclaveProcessCommandType::Describe,
             EnclaveProcessCommandType::GetEnclaveCID,
             EnclaveProcessCommandType::GetEnclaveFlags,
+            EnclaveProcessCommandType::GetEnclaveName,
             EnclaveProcessCommandType::ConnectionListenerStop,
         ];
         let cmds_read_only = vec![
             EnclaveProcessCommandType::Describe,
             EnclaveProcessCommandType::GetEnclaveCID,
             EnclaveProcessCommandType::GetEnclaveFlags,
+            EnclaveProcessCommandType::GetEnclaveName,
         ];
         let mut policy = HashMap::new();
 

--- a/src/enclave_proc/cpu_info.rs
+++ b/src/enclave_proc/cpu_info.rs
@@ -277,6 +277,7 @@ mod tests {
             debug_mode: None,
             cpu_ids: None,
             cpu_count: Some(343),
+            enclave_name: None,
         };
 
         let mut result = cpu_info.get_cpu_config(&run_args);
@@ -308,6 +309,7 @@ mod tests {
             debug_mode: None,
             cpu_ids: None,
             cpu_count: Some(2),
+            enclave_name: None,
         };
 
         let mut result = cpu_info.get_cpu_config(&run_args);

--- a/src/enclave_proc/cpu_info.rs
+++ b/src/enclave_proc/cpu_info.rs
@@ -277,7 +277,7 @@ mod tests {
             debug_mode: None,
             cpu_ids: None,
             cpu_count: Some(343),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
 
         let mut result = cpu_info.get_cpu_config(&run_args);
@@ -309,7 +309,7 @@ mod tests {
             debug_mode: None,
             cpu_ids: None,
             cpu_count: Some(2),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
 
         let mut result = cpu_info.get_cpu_config(&run_args);

--- a/src/enclave_proc/utils.rs
+++ b/src/enclave_proc/utils.rs
@@ -55,12 +55,14 @@ pub fn get_enclave_describe_info(
 
 /// Obtain the enclave information requested by the `run-enclaves` command.
 pub fn get_run_enclaves_info(
+    enclave_name: String,
     enclave_cid: u64,
     slot_id: u64,
     cpu_ids: Vec<u32>,
     memory: u64,
 ) -> NitroCliResult<EnclaveRunInfo> {
     let info = EnclaveRunInfo::new(
+        enclave_name,
         generate_enclave_id(slot_id)?,
         enclave_cid,
         cpu_ids.len(),
@@ -175,12 +177,14 @@ mod tests {
     /// exactly the same values as the supplied arguments.
     #[test]
     fn test_get_run_enclaves_info() {
+        let enclave_name = "testName".to_string();
         let enclave_cid: u64 = 0;
         let slot_id: u64 = 7;
         let cpu_ids: Vec<u32> = vec![1, 3];
         let memory: u64 = 64;
 
-        let result = get_run_enclaves_info(enclave_cid, slot_id, cpu_ids.clone(), memory);
+        let result =
+            get_run_enclaves_info(enclave_name, enclave_cid, slot_id, cpu_ids.clone(), memory);
 
         assert!(result.is_ok());
 
@@ -198,12 +202,14 @@ mod tests {
     /// id, which is obtained through a call to `get_run_enclaves_info()`.
     #[test]
     fn test_get_enclave_id() {
+        let enclave_name = "testName".to_string();
         let enclave_cid: u64 = 0;
         let slot_id: u64 = 8;
         let cpu_ids: Vec<u32> = vec![1, 3];
         let memory: u64 = 64;
 
-        let result = get_run_enclaves_info(enclave_cid, slot_id, cpu_ids.clone(), memory);
+        let result =
+            get_run_enclaves_info(enclave_name, enclave_cid, slot_id, cpu_ids.clone(), memory);
 
         assert!(result.is_ok());
 

--- a/src/enclave_proc/utils.rs
+++ b/src/enclave_proc/utils.rs
@@ -42,6 +42,7 @@ pub fn get_enclave_describe_info(
     let (slot_uid, enclave_cid, cpus_count, cpu_ids, memory_mib, flags, state) =
         enclave_manager.get_description_resources()?;
     let info = EnclaveDescribeInfo::new(
+        None,
         generate_enclave_id(slot_uid)?,
         enclave_cid,
         cpus_count,
@@ -49,6 +50,7 @@ pub fn get_enclave_describe_info(
         memory_mib,
         state.to_string(),
         flags_to_string(flags),
+        None,
     );
     Ok(info)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,13 @@ use std::io::{self, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 
-use common::commands_parser::{BuildEnclavesArgs, EmptyArgs};
+use common::commands_parser::{BuildEnclavesArgs, EmptyArgs, RunEnclavesArgs};
 use common::json_output::{DescribeEifInfo, EnclaveBuildInfo, EnclaveTerminateInfo};
 use common::{enclave_proc_command_send_single, get_sockets_dir_path};
 use common::{EnclaveProcessCommandType, NitroCliErrorEnum, NitroCliFailure, NitroCliResult};
-use enclave_proc_comm::enclave_process_handle_all_replies;
+use enclave_proc_comm::{
+    enclave_proc_command_send_all, enclave_proc_handle_outputs, enclave_process_handle_all_replies,
+};
 use log::info;
 
 use utils::Console;
@@ -153,6 +155,35 @@ pub fn build_from_docker(
     );
 
     Ok((file_output, measurements))
+}
+
+/// Creates new enclave name
+///
+/// Requests the names of all running instances and checks the
+/// occurrence of the chosen name for the new enclave.
+pub fn new_enclave_name(run_args: RunEnclavesArgs, names: Vec<String>) -> NitroCliResult<String> {
+    let enclave_name = match run_args.enclave_name {
+        Some(enclave_name) => enclave_name,
+        None => {
+            // Get name of EIF file from path eg. path/to/eif/hello.eif -> hello
+            // If the extension is missing, the whole file name will be chosen
+            let path_split: Vec<&str> = run_args.eif_path.split('/').collect();
+            path_split[path_split.len() - 1]
+                .trim_end_matches(".eif")
+                .to_string()
+        }
+    };
+
+    let mut idx = 0;
+    let mut result_name = enclave_name.clone();
+
+    // If duplicates are found, add index to name eg. testName -> testName_1 -> testName_2 ..
+    while names.contains(&result_name) {
+        idx += 1;
+        result_name = enclave_name.clone() + &'_'.to_string() + &idx.to_string();
+    }
+
+    Ok(result_name)
 }
 
 /// Returns information related to the given EIF
@@ -368,6 +399,26 @@ pub fn terminate_all_enclaves() -> NitroCliResult<()> {
     .map_err(|e| e.add_subaction("Failed to handle all enclave processes replies".to_string()))
 }
 
+/// Queries all enclaves for their name
+pub fn get_all_enclave_names() -> NitroCliResult<Vec<String>> {
+    let (comms, _) =
+        enclave_proc_command_send_all::<EmptyArgs>(EnclaveProcessCommandType::GetEnclaveName, None)
+            .map_err(|e| {
+                e.add_subaction(
+                    "Failed to send GetEnclaveName command to all enclave processes".to_string(),
+                )
+                .set_action("Get Enclave Names".to_string())
+            })?;
+
+    let mut replies: Vec<UnixStream> = vec![];
+    replies.extend(comms);
+    let objects = enclave_proc_handle_outputs::<String>(&mut replies)
+        .iter()
+        .map(|v| v.0.clone())
+        .collect();
+    Ok(objects)
+}
+
 /// Macro defining the arguments configuration for a *Nitro CLI* application.
 #[macro_export]
 macro_rules! create_app {
@@ -434,6 +485,14 @@ macro_rules! create_app {
                                 enclave_cid + 10000. \n The stream could be accessed with the console \
                                 sub-command" ,
                             )
+                            .conflicts_with("config"),
+                    )
+                    .arg(
+                        Arg::with_name("enclave-name")
+                            .long("enclave-name")
+                            .takes_value(true)
+                            .help("Custom name assigned to the enclave by the user")
+                            .required(false)
                             .conflicts_with("config"),
                     )
                     .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ use nitro_cli::enclave_proc_comm::{
     enclave_proc_get_flags, enclave_proc_spawn, enclave_process_handle_all_replies,
 };
 use nitro_cli::{
-    build_enclaves, console_enclaves, create_app, describe_eif, new_nitro_cli_failure,
-    terminate_all_enclaves,
+    build_enclaves, console_enclaves, create_app, describe_eif, get_all_enclave_names,
+    new_enclave_name, new_nitro_cli_failure, terminate_all_enclaves,
 };
 
 const RUN_ENCLAVE_STR: &str = "Run Enclave";
@@ -39,6 +39,7 @@ const TERMINATE_ALL_ENCLAVES_STR: &str = "Terminate All Enclaves";
 const BUILD_ENCLAVE_STR: &str = "Build Enclave";
 const ENCLAVE_CONSOLE_STR: &str = "Enclave Console";
 const EXPLAIN_ERR_STR: &str = "Explain Error";
+const NEW_NAME_STR: &str = "New Enclave Name";
 
 /// *Nitro CLI* application entry point.
 fn main() {
@@ -70,7 +71,7 @@ fn main() {
 
     match args.subcommand() {
         ("run-enclave", Some(args)) => {
-            let run_args = RunEnclavesArgs::new_with(args)
+            let mut run_args = RunEnclavesArgs::new_with(args)
                 .map_err(|err| {
                     err.add_subaction("Failed to construct RunEnclave arguments".to_string())
                         .set_action(RUN_ENCLAVE_STR.to_string())
@@ -82,6 +83,21 @@ fn main() {
                         .set_action(RUN_ENCLAVE_STR.to_string())
                 })
                 .ok_or_exit_with_errno(None);
+
+            let names = get_all_enclave_names()
+                .map_err(|e| {
+                    e.add_subaction("Failed to handle all enclave process replies".to_string())
+                        .set_action("Get Enclaves Name".to_string())
+                })
+                .ok_or_exit_with_errno(None);
+            run_args.enclave_name = Some(
+                new_enclave_name(run_args.clone(), names)
+                    .map_err(|err| {
+                        err.add_subaction("Failed to assign a new enclave name".to_string())
+                            .set_action(NEW_NAME_STR.to_string())
+                    })
+                    .ok_or_exit_with_errno(None),
+            );
 
             enclave_proc_command_send_single(
                 EnclaveProcessCommandType::Run,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use nitro_cli::common::commands_parser::{
     BuildEnclavesArgs, ConsoleArgs, EmptyArgs, ExplainArgs, RunEnclavesArgs, TerminateEnclavesArgs,
 };
 use nitro_cli::common::document_errors::explain_error;
-use nitro_cli::common::json_output::{DescribeOutput, EnclaveRunInfo, EnclaveTerminateInfo};
+use nitro_cli::common::json_output::{EnclaveDescribeInfo, EnclaveRunInfo, EnclaveTerminateInfo};
 use nitro_cli::common::{
     enclave_proc_command_send_single, logger, NitroCliErrorEnum, NitroCliFailure, NitroCliResult,
 };
@@ -184,7 +184,7 @@ fn main() {
 
             info!("Sent command: Describe");
             replies.extend(comms);
-            enclave_process_handle_all_replies::<DescribeOutput>(
+            enclave_process_handle_all_replies::<EnclaveDescribeInfo>(
                 &mut replies,
                 comm_errors,
                 true,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -146,6 +146,20 @@ def terminate_enclave_ok(enclave_id):
     return run_subprocess_ok(args)
 
 
+def terminate_enclave_by_name(enclave_name):
+    """
+    Terminates an enclave with the given name and checks the command was successful
+    :return: An instance of a CompletedProcess
+    """
+    args = [
+        "nitro-cli",
+        "terminate-enclave",
+        "--enclave-name", enclave_name
+    ]
+
+    return run_subprocess_ok(args)
+
+
 def describe_enclaves_ok():
     """
     Runs describe_enclaves command and checks the command was successful
@@ -180,6 +194,18 @@ def connect_console(enclave_id, timeout=None):
 
     if timeout is not None:
         args.extend(["--disconnect-timeout", str(timeout)])
+
+    return subprocess.Popen(args, stdout=PIPE, stderr=PIPE)
+
+
+def connect_console_by_name(enclave_name):
+    """
+    Connects to the enclave console defined by the enclave name
+    :return: The handle to the running process
+    """
+    args = ["nitro-cli",
+            "console",
+            "--enclave-name", enclave_name]
 
     return subprocess.Popen(args, stdout=PIPE, stderr=PIPE)
 

--- a/tests/test_nitro_cli_args.rs
+++ b/tests/test_nitro_cli_args.rs
@@ -51,6 +51,41 @@ mod test_nitro_cli_args {
     }
 
     #[test]
+    fn terminate_enclave_name() {
+        let app = create_app!();
+        let args = vec![
+            "nitro cli",
+            "terminate-enclave",
+            "--enclave-name",
+            "testName",
+        ];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), false)
+    }
+
+    #[test]
+    fn terminate_enclave_name_is_required() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "terminate-enclave", "--enclave-name"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
+    fn terminate_enclave_name_takes_multiple_values() {
+        let app = create_app!();
+        let args = vec![
+            "nitro cli",
+            "terminate-enclave",
+            "--enclave-name",
+            "name1",
+            "name2",
+        ];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
     fn describe_enclaves_correct_command() {
         let app = create_app!();
         let args = vec!["nitro cli", "describe-enclaves"];
@@ -113,6 +148,30 @@ mod test_nitro_cli_args {
     }
 
     #[test]
+    fn console_enclave_name() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "console", "--enclave-name", "testName"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), false)
+    }
+
+    #[test]
+    fn console_enclave_name_is_required() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "console", "--enclave-name"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
+    fn console_enclave_name_takes_multiple_values() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "console", "--enclave-name", "name1", "name2"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
     fn console_correct_disconnect_timeout_command() {
         let app = create_app!();
         let args = vec![
@@ -120,6 +179,21 @@ mod test_nitro_cli_args {
             "console",
             "--enclave-id",
             "i-1234_enc123",
+            "--disconnect-timeout",
+            "10",
+        ];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), false)
+    }
+
+    #[test]
+    fn console_correct_disconnect_timeout_command_with_name() {
+        let app = create_app!();
+        let args = vec![
+            "nitro cli",
+            "console",
+            "--enclave-name",
+            "testName",
             "--disconnect-timeout",
             "10",
         ];
@@ -435,6 +509,51 @@ mod test_nitro_cli_args {
             "1024",
             "--eif-path",
             "dir/image.eif",
+        ];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
+    fn run_enclave_correct_command_with_name() {
+        let app = create_app!();
+        let args = vec![
+            "nitro cli",
+            "run-enclave",
+            "--cpu-ids",
+            "10000",
+            "10001",
+            "--memory",
+            "512",
+            "--eif-path",
+            "dir/image.eif",
+            "--enclave-cid",
+            "1234",
+            "--debug-mode",
+            "--enclave-name",
+            "testName",
+        ];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), false)
+    }
+
+    #[test]
+    fn run_enclave_name_takes_value() {
+        let app = create_app!();
+        let args = vec![
+            "nitro cli",
+            "run-enclave",
+            "--cpu-ids",
+            "10000",
+            "10001",
+            "--memory",
+            "512",
+            "--eif-path",
+            "dir/image.eif",
+            "--enclave-cid",
+            "1234",
+            "--debug-mode",
+            "--enclave-name",
         ];
 
         assert_eq!(app.get_matches_from_safe(args).is_err(), true)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -256,6 +256,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 64,
             debug_mode: Some(true),
+            enclave_name: None,
         };
         run_describe_terminate(args);
     }
@@ -294,6 +295,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 256,
             debug_mode: Some(true),
+            enclave_name: None,
         };
         run_describe_terminate(args);
     }
@@ -327,6 +329,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 2046,
             debug_mode: Some(true),
+            enclave_name: None,
         };
         run_describe_terminate(args);
     }
@@ -424,6 +427,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 128,
             debug_mode: Some(true),
+            enclave_name: None,
         };
 
         run_describe_terminate(run_args);
@@ -458,6 +462,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 128,
             debug_mode: Some(false),
+            enclave_name: None,
         };
 
         let mut enclave_manager = run_enclaves(&run_args, None)
@@ -511,6 +516,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 128,
             debug_mode: Some(true),
+            enclave_name: None,
         };
 
         let mut enclave_manager = run_enclaves(&run_args, None)
@@ -594,6 +600,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 64,
             debug_mode: Some(true),
+            enclave_name: None,
         };
         let run_result = run_enclaves(&run_args, None).expect("Run enclaves failed");
         let mut enclave_manager = run_result.enclave_manager;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,7 +15,9 @@ mod tests {
         flags_to_string, generate_enclave_id, get_enclave_describe_info,
     };
     use nitro_cli::utils::Console;
-    use nitro_cli::{build_enclaves, build_from_docker, describe_eif, enclave_console};
+    use nitro_cli::{
+        build_enclaves, build_from_docker, describe_eif, enclave_console, new_enclave_name,
+    };
     use nitro_cli::{CID_TO_CONSOLE_PORT_OFFSET, VMADDR_CID_HYPERVISOR};
     use std::convert::TryInto;
     use std::fs::OpenOptions;
@@ -256,7 +258,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 64,
             debug_mode: Some(true),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
         run_describe_terminate(args);
     }
@@ -295,7 +297,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 256,
             debug_mode: Some(true),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
         run_describe_terminate(args);
     }
@@ -329,7 +331,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 2046,
             debug_mode: Some(true),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
         run_describe_terminate(args);
     }
@@ -427,7 +429,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 128,
             debug_mode: Some(true),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
 
         run_describe_terminate(run_args);
@@ -462,7 +464,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 128,
             debug_mode: Some(false),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
 
         let mut enclave_manager = run_enclaves(&run_args, None)
@@ -516,7 +518,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 128,
             debug_mode: Some(true),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
 
         let mut enclave_manager = run_enclaves(&run_args, None)
@@ -600,7 +602,7 @@ mod tests {
             cpu_count: Some(2),
             memory_mib: 64,
             debug_mode: Some(true),
-            enclave_name: None,
+            enclave_name: Some("testName".to_string()),
         };
         let run_result = run_enclaves(&run_args, None).expect("Run enclaves failed");
         let mut enclave_manager = run_result.enclave_manager;
@@ -621,7 +623,9 @@ mod tests {
 
         get_enclave_describe_info(&enclave_manager).unwrap();
         let build_info = enclave_manager.get_measurements().unwrap();
+        let enclave_name = enclave_manager.enclave_name.clone();
 
+        assert_eq!(enclave_name, "testName");
         assert_eq!(
             build_info.measurements.get(&"PCR0".to_string()).unwrap(),
             "93a8a6a775cd1e1ab8b6121d1b0ce08e99e0976dabfa40663fa8ea9633421305de18c8f95aa2b82d3feb918fe912c838"
@@ -637,6 +641,99 @@ mod tests {
 
         let _enclave_id = generate_enclave_id(0).expect("Describe enclaves failed");
         terminate_enclaves(&mut enclave_manager, None).expect("Terminate enclaves failed");
+    }
+
+    #[test]
+    fn build_run_default_enclave_name() {
+        let dir = tempdir().unwrap();
+        let eif_path = dir.path().join("test.eif");
+        setup_env();
+        let args = BuildEnclavesArgs {
+            docker_uri: SAMPLE_DOCKER.to_string(),
+            docker_dir: None,
+            output: eif_path.to_str().unwrap().to_string(),
+            signing_certificate: None,
+            private_key: None,
+        };
+
+        build_from_docker(
+            &args.docker_uri,
+            &args.docker_dir,
+            &args.output,
+            &args.signing_certificate,
+            &args.private_key,
+        )
+        .expect("Docker build failed")
+        .1;
+
+        setup_env();
+        let mut run_args = RunEnclavesArgs {
+            enclave_cid: None,
+            eif_path: args.output,
+            cpu_ids: None,
+            cpu_count: Some(2),
+            memory_mib: 64,
+            debug_mode: Some(true),
+            enclave_name: None,
+        };
+        let names = Vec::new();
+        run_args.enclave_name =
+            Some(new_enclave_name(run_args.clone(), names).expect("Failed to set new name."));
+        let run_result = run_enclaves(&run_args, None).expect("Run enclaves failed");
+        let mut enclave_manager = run_result.enclave_manager;
+
+        get_enclave_describe_info(&enclave_manager).unwrap();
+        let enclave_name = enclave_manager.enclave_name.clone();
+
+        // Assert that EIF name has been set
+        assert_eq!(enclave_name, "test");
+
+        terminate_enclaves(&mut enclave_manager, None).expect("Terminate enclaves failed");
+    }
+
+    #[test]
+    fn new_enclave_names() {
+        let dir = tempdir().unwrap();
+        let eif_path = dir.path().join("test.eif");
+
+        let mut run_args = RunEnclavesArgs {
+            enclave_cid: None,
+            eif_path: eif_path.to_str().unwrap().to_string(),
+            cpu_ids: None,
+            cpu_count: Some(2),
+            memory_mib: 64,
+            debug_mode: Some(true),
+            enclave_name: Some("enclaveName".to_string()),
+        };
+        let mut names = Vec::new();
+        let name =
+            new_enclave_name(run_args.clone(), names.clone()).expect("Failed to set new name.");
+        names.push(name);
+
+        run_args.enclave_name = Some("enclaveNameOther".to_string());
+        let name =
+            new_enclave_name(run_args.clone(), names.clone()).expect("Failed to set new name.");
+        names.push(name);
+
+        run_args.enclave_name = Some("enclaveName".to_string());
+        let name =
+            new_enclave_name(run_args.clone(), names.clone()).expect("Failed to set new name.");
+        names.push(name);
+
+        run_args.enclave_name = Some("enclaveName".to_string());
+        let name =
+            new_enclave_name(run_args.clone(), names.clone()).expect("Failed to set new name.");
+        names.push(name);
+
+        assert_eq!(
+            names,
+            vec![
+                "enclaveName",
+                "enclaveNameOther",
+                "enclaveName_1",
+                "enclaveName_2"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
### User friendly names for enclaves

Introducing a new option for the `run-enclaves` command allowing users to set custom names for running enclaves instead of using only the ID. The name is set following the option `--enclave-name` and will be uniquely assigned to each of the running enclaves. In case of name conflicts, an index will be concatenated to the initial name, incrementing until the name becomes unique. This action is optional and if no name is provided, the EIF name will take its place.
The name will be part of the output of the following commands: `run-enclave`, `describe-enclaves` and `terminate-enclave`.

Commands that use the ID for targeting a specific enclave, now have the option to address the enclave by its name. So the commands `console` and `terminate-enclave` will have the option to use `--enclave-name` instead of `--enclave-id`.

Unique name assigning is done by the CLI process by broadcasting a request for all the running enclaves' names. The new name is checked agains all the others and saved in the EnclaveManager or changed if needed (with the index added) . Name addressing for the other commands is done by sending, again, to all te running enclaves, the name provided by the user. The matching enclave will send its ID and the command will be executed as before, using the ID.

### Command outputs

```
$ ./nitro-cli run-enclave --cpu-count 2 --memory 256 --enclave-cid 16 --eif-path hello.eif --enclave-name testName --debug-mode
Start allocating memory...
Started enclave with enclave-cid: 16, memory: 256 MiB, cpu-ids: [1, 9]
{
  "EnclaveName": "testName",
  "EnclaveID": "i-0584873aac8fea23b-enc17b9c558602bf9f",
  "ProcessID": 652683,
  "EnclaveCID": 16,
  "NumberOfCPUs": 2,
  "CPUIDs": [
    1,
    9
  ],
  "MemoryMiB": 256
}

$ ./nitro-cli describe-enclaves
[
  {
    "EnclaveName": "testName",
    "EnclaveID": "i-0584873aac8fea23b-enc17b9c558602bf9f",
    "ProcessID": 652683,
    "EnclaveCID": 16,
    "NumberOfCPUs": 2,
    "CPUIDs": [
      1,
      9
    ],
    "MemoryMiB": 256,
    "State": "RUNNING",
    "Flags": "DEBUG_MODE",
    "Measurements": {
      "HashAlgorithm": "Sha384 { ... }",
      "PCR0": "3eaa317a778ee207fab894f6b42c5545ddef8bd905da8cc2f22cc59cc83fe0c980a411e5f5445f110f26d5c0d6f39ee4",
      "PCR1": "aca6e62ffbf5f7deccac452d7f8cee1b94048faf62afc16c8ab68c9fed8c38010c73a669f9a36e596032f0b973d21895",
      "PCR2": "ea436e643c31f2891161803e3f22084a12d38f807ef733379cadf789ec85d51e3bb787f48f3cad0c291fbc82fe7ca27d"
    }
  }
]

$ ./nitro-cli console --enclave-name testName
Connecting to the console for enclave 16...
Successfully connected to the console.
[    0.000000] Linux version 4.14.177-104.253.amzn2.x86_64 (mockbuild@ip-10-0-1-32) (gcc version 7.3.1 20180712 (Red Hat 7.3.1-6) (GCC)) #1 SMP Fri May 1 02:01:13 UTC 2020
..........

```
In the scenario that two enclaves could run simultaneously, a second run command with the exact name will result:

```
$ ./nitro-cli run-enclave --cpu-count 2 --memory 256 --enclave-cid 16 --eif-path hello.eif --enclave-name testName --debug-mode
Start allocating memory...
Started enclave with enclave-cid: 16, memory: 256 MiB, cpu-ids: [1, 9]
{
  "EnclaveName": "testName_1",
  "EnclaveID": "i-0584873aac8fea23b-enc17b9c55other_id",
  "ProcessID": 652683,
  "EnclaveCID": 16,
  "NumberOfCPUs": 2,
  "CPUIDs": [
    1,
    9
  ],
  "MemoryMiB": 256
}
```

```
$ ./nitro-cli terminate-enclave --enclave-name testName
Successfully terminated enclave i-0584873aac8fea23b-enc17b9c558602bf9f.
{
  "EnclaveName": "testName",
  "EnclaveID": "i-0584873aac8fea23b-enc17b9c558602bf9f",
  "Terminated": true
}
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
