### PR TITLE
docs: Update references to the AWS Nitro Enclaves COSE crate

### DIFF
--- a/docs/image_signing.md
+++ b/docs/image_signing.md
@@ -47,7 +47,8 @@ The PCR Signature contains the PEM-formatted signing certificate
 and the serialized `COSESign1` object generated using the byte array
 formed from the PCR's index and its value as payload and the
 private key as signing key. The implementation of `COSESign1`
-and more details can be found in the [rust-cose](../rust-cose) crate.
+and more details can be found in the following crate:
+[aws-nitro-enclaves-cose](https://github.com/awslabs/aws-nitro-enclaves-cose).
 
 ### How to Verify the Signature
 
@@ -58,6 +59,7 @@ headers in the [eif-defs](../eif_defs) crate.
 
 2. For each PCR Signature use the public key from the signing
 certificate to decrypt the payload from the `COSESign1` object
-(this can be done using the [rust-cose](../rust-cose) crate) and
-check that the PCR's value is the same as the one computed by
+(this can be done using the following crate:
+[aws-nitro-enclaves-cose](https://github.com/awslabs/aws-nitro-enclaves-cose))
+and check that the PCR's value is the same as the one computed by
 Nitro CLI.


### PR DESCRIPTION
The AWS Nitro Enclaves COSE crate codebase has been moved to its own
GitHub repository.

Update the COSE references from the image signing docs to point to this
GitHub repository.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
