### PR TITLE
build: Extend nitro-cli build with enclave_build source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ init: init.c build-setup
 	strip --strip-all $(OBJ_PATH)/init
 
 # See .build-container rule for explanation.
-.build-nitro-cli: $(shell find $(BASE_PATH)/src -name "*.rs")
+.build-nitro-cli: $(shell find $(BASE_PATH)/src $(BASE_PATH)/enclave_build/src -name "*.rs")
 	$(DOCKER) run \
 		-v "$$(readlink -f ${BASE_PATH})":/nitro_src \
 		-v "$$(readlink -f ${OBJ_PATH})":/nitro_build \


### PR DESCRIPTION
Nitro-cli build checks if the files under src are modified.
It does not check for the enclave_build crate. As a result,
the "make nitro-cli" command would not build a new version
of nitro-cli with modified enclave_build.

Given that enclave_build is part of the build command,
extend the make rules to capture those changes.

Signed-off-by: Alexandru Vasile <lexnv@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
