### PR TITLE
run-enclave: Verify signing certificate

### DIFF
--- a/src/common/document_errors.rs
+++ b/src/common/document_errors.rs
@@ -67,6 +67,7 @@ lazy_static! {
             (NitroCliErrorEnum::LoggerError, "E56"),
             (NitroCliErrorEnum::HasherError, "E57"),
             (NitroCliErrorEnum::EnclaveNamingError, "E58"),
+            (NitroCliErrorEnum::EIFSignatureCheckerError, "E59"),
         ].iter().cloned().collect();
 }
 
@@ -328,6 +329,9 @@ pub fn get_detailed_info(error_code_str: String, additional_info: &[String]) -> 
         }
         "E58" => {
             ret.push_str("Naming error. Such error appears when trying to perform an enclave operation using the enclave name and the name is invalid.");
+        }
+        "E59" => {
+            ret.push_str("EIF signature checker error. Such error appears when validation of the signing certificate fails.");
         }
         _ => {
             ret.push_str(format!("No such error code {}", error_code_str).as_str());

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -176,6 +176,8 @@ pub enum NitroCliErrorEnum {
     HasherError,
     /// Enclave naming error
     EnclaveNamingError,
+    /// Signature checker error
+    EIFSignatureCheckerError,
 }
 
 impl Default for NitroCliErrorEnum {


### PR DESCRIPTION
### Verify signing certificate before loading the image

To avoid ambiguous errors for invalid signed EIFs, `run-enclave` command extracts the signature section from the image and performs certificate validation. It checks the .pem format of the certificate, the signature against the public key and if the certificate is expired.

Suggestive error messages along with a new error code have been added to make the output more explicit.

Output:

```
$ ./nitro-cli run-enclave --cpu-count 2 --memory 256 --eif-path hello-expired.eif 
[ E59 ] Signature checker error. Such error appears when validation of the signing certificate fails.

For more details, please visit https://docs.aws.amazon.com/enclaves/latest/user/cli-errors.html#E59

If you open a support ticket, please provide the error log found at "/var/log/nitro_enclaves/err2021-09-24T09:12:45.367481952+00:00.log"
Failed connections: 1
[ E39 ] Enclave process connection failure. Such error appears when the enclave manager fails to connect to at least one enclave process for retrieving the description information.

For more details, please visit https://docs.aws.amazon.com/enclaves/latest/user/cli-errors.html#E39

If you open a support ticket, please provide the error log found at "/var/log/nitro_enclaves/err2021-09-24T09:12:45.367624877+00:00.log"

$ cat /var/log/nitro_enclaves/err2021-09-24T09:12:45.367481952+00:00.log
  Action: Run Enclave
  Subactions:
    Failed to execute command `Run`
    Failed to trigger enclave run
    Invalid signing certificate: "The signing certificate is expired"
  Root error file: src/enclave_proc/commands.rs
  Root error line: 83
  Build commit: v1.0.12-38-ga3476c6-dirty
```

Issue #243 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
