### PR TITLE
NitroCLI `pcr` command

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,6 +35,14 @@ const SO_VM_SOCKETS_CONNECT_TIMEOUT: i32 = 6;
 /// The amount of time to wait between consecutive console reads, in milliseconds.
 const TIMEOUT: u64 = 100;
 
+/// Defines the types of PCRs that can be measured by `pcr` command
+pub enum PcrType {
+    /// Used for files containing the bytes for hashing
+    DefaultType,
+    /// Used for `.pem` files that we want to hash. Additional serializing is needed
+    SigningCertificate,
+}
+
 /// The structure representing the console of an enclave.
 pub struct Console {
     /// The file descriptor used for connecting to the enclave's console.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -16,6 +16,8 @@ TEST_IMAGES = "test_images/"
 ARCH =  subprocess.run(["uname", "-m"], stdout=PIPE, stderr=PIPE,
         check=False).stdout.decode('UTF-8').rstrip("\n")
 SAMPLE_EIF = "vsock-sample-server-" + ARCH + ".eif"
+SIGNED_EIF = "vsock-sample-server-" + ARCH + "-signed.eif"
+SIGN_CERT = "cert.pem"
 
 
 def run_cmd_ok(cmd_string):
@@ -221,3 +223,18 @@ def get_cpu_count():
     output = result.stdout.decode('UTF-8').splitlines()
     cpu_ids = [id for id in output if not id.startswith("#")]
     return len(cpu_ids)
+
+
+def get_pcr(cert_name):
+    """
+    Runs pcr command, hashing the file at the given path
+    :return: PCR value of the input and returns a CompletedProcess
+    """
+    cert_path = TEST_IMAGES + cert_name
+    args = [
+        "nitro-cli",
+        "pcr",
+        "--signing-certificate",
+        cert_path,
+    ]
+    return run_subprocess_ok(args)

--- a/tests/test_nitro_cli_args.rs
+++ b/tests/test_nitro_cli_args.rs
@@ -558,4 +558,43 @@ mod test_nitro_cli_args {
 
         assert_eq!(app.get_matches_from_safe(args).is_err(), true)
     }
+
+    #[test]
+    fn pcr_input_takes_value() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "pcr", "--input"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
+    fn pcr_certificate_takes_value() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "pcr", "--signing-certificate"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
+    fn pcr_conflicting_arguments() {
+        let app = create_app!();
+        let args = vec![
+            "nitro cli",
+            "pcr",
+            "--signing-certificate",
+            "cert.pem",
+            "--input",
+            "test.bin",
+        ];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), true)
+    }
+
+    #[test]
+    fn pcr_certificate_correct() {
+        let app = create_app!();
+        let args = vec!["nitro cli", "pcr", "--signing-certificate", "cert.pem"];
+
+        assert_eq!(app.get_matches_from_safe(args).is_err(), false)
+    }
 }


### PR DESCRIPTION
New command for getting the PCR value from an input file. Currently takes two types of arguments with the options: `--input` a general use to hash all the bytes from a file and `--signing-certificate` for retrieving PCR8 from a .pem file. The second type in particular, performs additional serialisation of a DER-encoded structure before hashing the content.

The purpose of the command is to identify the certificate used to sign a certain EIF, by finding the PCR8 and comparing it to the build measurement of the EIF.

Output:

```
$ ./nitro-cli pcr --signing-certificate cert.pem
{
  "PCR8": "e6eb66339de75e8ed2939e9524cba83aa96f2c79eaf5d5ac3bacf2cb76c75a31f983d0b80f55b29f0acd256b8cff1999"
}

$ ./nitro-cli build-enclave --docker-uri hello:latest --output-file hello-sample-signed.eif --private-key key.pem --signing-certificate cert.pem
Start building the Enclave Image...
Using the locally available Docker image...
Enclave Image successfully created.
{
  "Measurements": {
    "HashAlgorithm": "Sha384 { ... }",
    "PCR0": "3eaa317a778ee207fab894f6b42c5545ddef8bd905da8cc2f22cc59cc83fe0c980a411e5f5445f110f26d5c0d6f39ee4",
    "PCR1": "aca6e62ffbf5f7deccac452d7f8cee1b94048faf62afc16c8ab68c9fed8c38010c73a669f9a36e596032f0b973d21895",
    "PCR2": "ea436e643c31f2891161803e3f22084a12d38f807ef733379cadf789ec85d51e3bb787f48f3cad0c291fbc82fe7ca27d",
    "PCR8": "e6eb66339de75e8ed2939e9524cba83aa96f2c79eaf5d5ac3bacf2cb76c75a31f983d0b80f55b29f0acd256b8cff1999"
  }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
