### PR TITLE
vsock_proxy/README: Update vsock proxy configuration file location

### DIFF
--- a/vsock_proxy/README.md
+++ b/vsock_proxy/README.md
@@ -35,7 +35,7 @@ FLAGS:
 OPTIONS:
         --config <config_file>     YAML file containing the services that
                                    can be forwarded.
-                                    [default: /etc/vsock_proxy/config.yaml]
+                                    [default: /etc/nitro_enclaves/vsock-proxy.yaml]
     -w, --num_workers <workers>    Set the maximum number of simultaneous
                                    connections supported. [default: 4]
 
@@ -76,7 +76,7 @@ from a domain name); this is mutually exclusive with the `--ipv4` flag
 
 * `--config <config_file`  
 -> to limit the services that the vsock proxy can forward to, we use a configuration file that
-contains an allowlist of accessible services; the default location of this file is `/etc/vsock_proxy/config.yaml`;
+contains an allowlist of accessible services; the default location of this file is `/etc/nitro_enclaves/vsock-proxy.yaml`;
 we specify the format of this file in a later section
 
 * `-w, --num_workers <workers>`  
@@ -89,7 +89,7 @@ is 4
 The configuration file is in YAML format. It should have a key, `allowlist`, and a corresponding list
 of accepted endpoints.  
 We define an accepted endpoint by two keys: `address` and `port`, and their corresponding values.  
-A configuration file example can be found in `configs/config.yaml`.
+A configuration file example can be found in `configs/vsock-proxy.yaml`.
 
 ### Vsock proxy service
 
@@ -98,5 +98,5 @@ After installing the Nitro CLI RPM, the vsock proxy can be run as a service usin
 systemctl enable nitro-enclaves-vsock-proxy.service
 ```
 The service files can be found in `service` directory. The proxy is ran using the default configuration
-from `/etc/vsock_proxy/config.yaml`, on local port 8000 and the AWS KMS endpoint corresponding to
+from `/etc/nitro_enclaves/vsock-proxy.yaml`, on local port 8000 and the AWS KMS endpoint corresponding to
 the region of the instance.


### PR DESCRIPTION
Update the location of the vsock proxy configuration file in the vsock
proxy README, to match the current location.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #303*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
