### PR TITLE
tests: Update vsock sample tests for Arm support

### DIFF
--- a/enclave_build/src/docker.rs
+++ b/enclave_build/src/docker.rs
@@ -406,8 +406,13 @@ mod tests {
     /// Test extracted configuration is as expected
     #[test]
     fn test_config() {
+        #[cfg(target_arch = "x86_64")]
         let docker = DockerUtil::new(String::from(
-            "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample",
+            "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample-server-x86_64",
+        ));
+        #[cfg(target_arch = "aarch64")]
+        let docker = DockerUtil::new(String::from(
+            "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample-server-aarch64",
         ));
 
         let (cmd_file, env_file) = docker.load().unwrap();
@@ -418,9 +423,9 @@ mod tests {
         cmd_file.read_to_string(&mut cmd).unwrap();
         assert_eq!(
             cmd,
-            "/nc-vsock\n\
-             -l\n\
-             5000\n"
+            "/bin/sh\n\
+             -c\n\
+             ./vsock-sample server --port 5005\n"
         );
 
         let mut env = String::new();

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,7 +27,7 @@ function clean_up_and_exit() {
 	make clean
 	rm -rf test_images
 	# Cleanup pulled images during testing
-	docker rmi 667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample 2> /dev/null || true
+	docker rmi 667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample-server-"${ARCH}" 2> /dev/null || true
 	docker rmi hello-world:latest 2> /dev/null || true
 
 	rm -rf examples/"${ARCH}"/hello-entrypoint
@@ -98,8 +98,8 @@ mkdir -p /var/log/nitro_enclaves || test_failed
 # Build EIFS for testing
 mkdir -p test_images || test_failed
 export HOME="/root"
-nitro-cli build-enclave --docker-uri 667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample \
-	--output-file test_images/vsock-sample.eif || test_failed
+nitro-cli build-enclave --docker-uri 667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample-server-"${ARCH}" \
+	--output-file test_images/vsock-sample-server-"${ARCH}".eif || test_failed
 
 # Build enclave image using Docker ENTRYPOINT instruction
 mkdir -p examples/"${ARCH}"/hello-entrypoint || test_failed

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/python3
 """
@@ -13,7 +13,9 @@ import signal
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__)) + "/../../"
 TEST_IMAGES = "test_images/"
-SAMPLE_EIF = "vsock-sample.eif"
+ARCH =  subprocess.run(["uname", "-m"], stdout=PIPE, stderr=PIPE,
+        check=False).stdout.decode('UTF-8').rstrip("\n")
+SAMPLE_EIF = "vsock-sample-server-" + ARCH + ".eif"
 
 
 def run_cmd_ok(cmd_string):

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #![deny(warnings)]
 
@@ -32,8 +32,12 @@ mod tests {
     use openssl::x509::{X509Name, X509};
 
     // Remote Docker image
+    #[cfg(target_arch = "x86_64")]
     const SAMPLE_DOCKER: &str =
-        "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample";
+        "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample-server-x86_64";
+    #[cfg(target_arch = "aarch64")]
+    const SAMPLE_DOCKER: &str =
+        "667861386598.dkr.ecr.us-east-1.amazonaws.com/enclaves-samples:vsock-sample-server-aarch64";
     // Local Docker image
     const COMMAND_EXECUTER_DOCKER: &str = "command_executer:eif";
 
@@ -87,17 +91,35 @@ mod tests {
         )
         .expect("Docker build failed")
         .1;
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             measurements.get("PCR0").unwrap(),
-            "93a8a6a775cd1e1ab8b6121d1b0ce08e99e0976dabfa40663fa8ea9633421305de18c8f95aa2b82d3feb918fe912c838"
+            "4e408fd54d73aef49fc02087b282eaba9691c9fa4174b2a9b68d7b1d52132609ec9953df0f87ec384225afe305e9061d"
         );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            measurements.get("PCR0").unwrap(),
+            "e11d760e09bddd3f8ef84eb21dfdde1fd1fc0664b3cec852aa26eced5ab6b67b3261a369dc2afdb6bef7fc1595eaa0cf"
+        );
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             measurements.get("PCR1").unwrap(),
             "c35e620586e91ed40ca5ce360eedf77ba673719135951e293121cb3931220b00f87b5a15e94e25c01fecd08fc9139342"
         );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            measurements.get("PCR1").unwrap(),
+            "1b8ff3c2f3338f04f64d8fc1f19ef7a6b432ed2dbe3157eac7ca6d0de775ff98c12de2f8a4560e2e218d5d8b2a1795c2"
+        );
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             measurements.get("PCR2").unwrap(),
-            "52528ebeccf82b21cea3f3a9d055f1bb3d18254d77dcda2bbd7f39cecd96b7eea842913800cc1b0bc261b7ad1b83be90"
+            "10ffd6773d365539696fa3520c28312cf657152fc3f89538d02af5e8b579e964a9f9a5c763470a122763f4fd0a1dd2d7"
+        );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            measurements.get("PCR2").unwrap(),
+            "28737c9aa5d964c0daaddd1460b7b50c46788f1c037aa6317d66b3eb95823840c0ae774e6ee744deb8293265d97bbd1f"
         );
     }
 
@@ -215,17 +237,35 @@ mod tests {
         )
         .expect("Docker build failed")
         .1;
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             measurements.get("PCR0").unwrap(),
-            "93a8a6a775cd1e1ab8b6121d1b0ce08e99e0976dabfa40663fa8ea9633421305de18c8f95aa2b82d3feb918fe912c838"
+            "4e408fd54d73aef49fc02087b282eaba9691c9fa4174b2a9b68d7b1d52132609ec9953df0f87ec384225afe305e9061d"
         );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            measurements.get("PCR0").unwrap(),
+            "e11d760e09bddd3f8ef84eb21dfdde1fd1fc0664b3cec852aa26eced5ab6b67b3261a369dc2afdb6bef7fc1595eaa0cf"
+        );
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             measurements.get("PCR1").unwrap(),
             "c35e620586e91ed40ca5ce360eedf77ba673719135951e293121cb3931220b00f87b5a15e94e25c01fecd08fc9139342"
         );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            measurements.get("PCR1").unwrap(),
+            "1b8ff3c2f3338f04f64d8fc1f19ef7a6b432ed2dbe3157eac7ca6d0de775ff98c12de2f8a4560e2e218d5d8b2a1795c2"
+        );
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             measurements.get("PCR2").unwrap(),
-            "52528ebeccf82b21cea3f3a9d055f1bb3d18254d77dcda2bbd7f39cecd96b7eea842913800cc1b0bc261b7ad1b83be90"
+            "10ffd6773d365539696fa3520c28312cf657152fc3f89538d02af5e8b579e964a9f9a5c763470a122763f4fd0a1dd2d7"
+        );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            measurements.get("PCR2").unwrap(),
+            "28737c9aa5d964c0daaddd1460b7b50c46788f1c037aa6317d66b3eb95823840c0ae774e6ee744deb8293265d97bbd1f"
         );
     }
 
@@ -256,7 +296,7 @@ mod tests {
             eif_path: build_args.output,
             cpu_ids: None,
             cpu_count: Some(2),
-            memory_mib: 64,
+            memory_mib: 128,
             debug_mode: Some(true),
             enclave_name: Some("testName".to_string()),
         };
@@ -600,7 +640,7 @@ mod tests {
             eif_path: args.output,
             cpu_ids: None,
             cpu_count: Some(2),
-            memory_mib: 64,
+            memory_mib: 128,
             debug_mode: Some(true),
             enclave_name: Some("testName".to_string()),
         };
@@ -626,17 +666,35 @@ mod tests {
         let enclave_name = enclave_manager.enclave_name.clone();
 
         assert_eq!(enclave_name, "testName");
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             build_info.measurements.get(&"PCR0".to_string()).unwrap(),
-            "93a8a6a775cd1e1ab8b6121d1b0ce08e99e0976dabfa40663fa8ea9633421305de18c8f95aa2b82d3feb918fe912c838"
+            "4e408fd54d73aef49fc02087b282eaba9691c9fa4174b2a9b68d7b1d52132609ec9953df0f87ec384225afe305e9061d"
         );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            build_info.measurements.get(&"PCR0".to_string()).unwrap(),
+            "e11d760e09bddd3f8ef84eb21dfdde1fd1fc0664b3cec852aa26eced5ab6b67b3261a369dc2afdb6bef7fc1595eaa0cf"
+        );
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             build_info.measurements.get(&"PCR1".to_string()).unwrap(),
             "c35e620586e91ed40ca5ce360eedf77ba673719135951e293121cb3931220b00f87b5a15e94e25c01fecd08fc9139342"
         );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            build_info.measurements.get(&"PCR1".to_string()).unwrap(),
+            "1b8ff3c2f3338f04f64d8fc1f19ef7a6b432ed2dbe3157eac7ca6d0de775ff98c12de2f8a4560e2e218d5d8b2a1795c2"
+        );
+        #[cfg(target_arch = "x86_64")]
         assert_eq!(
             build_info.measurements.get(&"PCR2".to_string()).unwrap(),
-            "52528ebeccf82b21cea3f3a9d055f1bb3d18254d77dcda2bbd7f39cecd96b7eea842913800cc1b0bc261b7ad1b83be90"
+            "10ffd6773d365539696fa3520c28312cf657152fc3f89538d02af5e8b579e964a9f9a5c763470a122763f4fd0a1dd2d7"
+        );
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(
+            build_info.measurements.get(&"PCR2".to_string()).unwrap(),
+            "28737c9aa5d964c0daaddd1460b7b50c46788f1c037aa6317d66b3eb95823840c0ae774e6ee744deb8293265d97bbd1f"
         );
 
         let _enclave_id = generate_enclave_id(0).expect("Describe enclaves failed");
@@ -672,7 +730,7 @@ mod tests {
             eif_path: args.output,
             cpu_ids: None,
             cpu_count: Some(2),
-            memory_mib: 64,
+            memory_mib: 128,
             debug_mode: Some(true),
             enclave_name: None,
         };
@@ -701,7 +759,7 @@ mod tests {
             eif_path: eif_path.to_str().unwrap().to_string(),
             cpu_ids: None,
             cpu_count: Some(2),
-            memory_mib: 64,
+            memory_mib: 128,
             debug_mode: Some(true),
             enclave_name: Some("enclaveName".to_string()),
         };


### PR DESCRIPTION
Update the tests that use the vsock sample to include Arm support. The
vsock sample is the one that can be found at:

https://github.com/aws/aws-nitro-enclaves-samples/tree/main/vsock_sample/rs

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
