### PR TITLE
samples/command_executer: Update symlink file for aarch64 kernel blob

### DIFF
--- a/samples/command_executer/resources/blobs/aarch64/Image
+++ b/samples/command_executer/resources/blobs/aarch64/Image
@@ -1,0 +1,1 @@
+../../../../../blobs/aarch64/Image

--- a/samples/command_executer/resources/blobs/aarch64/bzImage
+++ b/samples/command_executer/resources/blobs/aarch64/bzImage
@@ -1,1 +1,0 @@
-../../../../../blobs/aarch64/bzImage


### PR DESCRIPTION
The name of the aarch64 kernel image was changed from bzImage to Image.
Update the symlink file from the command executer blobs.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
