### PR TITLE
nitro-cli: Ignore chrono and time crates advisories till fix is avail…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ nitro-audit: build-setup build-container
 		-v "$$(readlink -f ${OBJ_PATH})":/nitro_build \
 		$(CONTAINER_TAG) bin/bash -c \
 			'source /root/.cargo/env && \
-			cargo audit -f /nitro_src/Cargo.lock'
+			cargo audit -f /nitro_src/Cargo.lock --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071'
 
 nitro-about: build-setup build-container
 	$(DOCKER) run \


### PR DESCRIPTION
…able

The following errors appear when running cargo audit:

Crate:         chrono
Version:       0.4.11
Title:         Potential segfault in `localtime_r` invocations
Date:          2020-11-10
ID:            RUSTSEC-2020-0159
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0159
Solution:      No safe upgrade is available!
Dependency tree:
chrono 0.4.11
├── shiplift 0.7.0
│   └── enclave_build 0.1.0
│       └── nitro-cli 1.0.12
├── nitro-cli 1.0.12
└── flexi_logger 0.15.2
    └── nitro-cli 1.0.12

Crate:         time
Version:       0.1.42
Title:         Potential segfault in the time crate
Date:          2020-11-18
ID:            RUSTSEC-2020-0071
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:      Upgrade to >=0.2.23
Dependency tree:
time 0.1.42
└── chrono 0.4.11
    ├── shiplift 0.7.0
    │   └── enclave_build 0.1.0
    │       └── nitro-cli 1.0.12
    ├── nitro-cli 1.0.12
    └── flexi_logger 0.15.2
        └── nitro-cli 1.0.12

Ignore the advisory till a new crate version that includes the fix is
available, or other crate(s) would be used instead.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
