### PR TITLE
nitro-cli: Update Cargo.lock/.toml and RPM spec for 1.1.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "nitro-cli"
-version = "1.0.12"
+version = "1.1.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitro-cli"
-version = "1.0.12"
+version = "1.1.0"
 authors = ["Alexandru Gheorghe <aggh@amazon.com>"]
 edition = "2018"
 

--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -17,7 +17,7 @@
 
 Summary:    AWS Nitro Enclaves tools for managing enclaves
 Name:       aws-nitro-enclaves-cli
-Version:    1.0.12
+Version:    1.1.0
 Release:    0%{?dist}
 
 License:    Apache 2.0
@@ -192,6 +192,30 @@ fi
 %{ne_include_dir}/*
 
 %changelog
+* Thu Oct 28 2021 Andra Paraschiv <andraprs@amazon.com> - 1.1.0-0
+- Update the enclave image blobs e.g. enclave kernel and NSM driver, to include
+  the hwrng functionality from the NSM driver for entropy seeding.
+- Exit if the hugepages configuration fails in the nitro-enclaves-allocator
+  service.
+- Update the enclave boot timeout logic to consider the enclave image size.
+- Verify the signing certificate of the enclave image and add explicit error
+  handling.
+- Add pcr command in the nitro-cli.
+- Add support for enclave name in the nitro-cli commands.
+- Add describe-eif command in the nitro-cli.
+- Set correct group ownership for /dev/nitro_enclaves in the nitro-cli spec.
+- Add --disconnect-timeout option to console command.
+- Add pylint fixes to the nitro-cli tests.
+- Update cargo-about and cargo-audit in the nitro-cli CI.
+- Update tar and hyper crates in the nitro-cli.
+- Fix remote server's matching against allowlist for vsock proxy.
+- Add refs for Nitro CLI install from sources on a set of Linux distros in the
+  nitro-cli docs.
+- Update references to the AWS Nitro Enclaves COSE crate in the nitro-cli docs.
+- Update vsock proxy configuration file location in the vsock proxy README.
+- Update command executer sample README to reflect current state.
+- Update Nitro CLI README to include information about enclave disk space.
+
 * Thu Jul 15 2021 Alexandru Gheorghe <aggh@amazon.com> - 1.0.12-0
 - Fix build-enclave when docker contains ENTRYPOINT command.
 

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -3553,7 +3553,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     
-                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.0.12</a></li>
+                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.1.0</a></li>
                     
                 </ul>
                 <pre class="license-text">


### PR DESCRIPTION
Update the nitro-cli version to 1.1.0 for a new release.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
