### PR TITLE
Update kernel check for add_cpu() and remove_cpu()

### DIFF
--- a/drivers/virt/nitro_enclaves/ne_misc_dev.c
+++ b/drivers/virt/nitro_enclaves/ne_misc_dev.c
@@ -139,7 +139,7 @@ static int user_access_ok(void __user *addr, unsigned long size)
 #endif
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0-1030)
 static int remove_cpu(u32 cpu_id)
 {
 	struct device *cpu_dev = NULL;
@@ -167,7 +167,7 @@ static int remove_cpu(u32 cpu_id)
 }
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0-1030)
 static int add_cpu(u32 cpu_id)
 {
 	struct device *cpu_dev = NULL;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

error: static declaration of ‘remove_cpu’ follows non-static declaration

error: static declaration of ‘add_cpu’ follows non-static declaration

Details here:

https://githubmemory.com/repo/aws/aws-nitro-enclaves-cli/issues/262

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
