### PR TITLE
README: Update Nitro Enclaves kernel driver availability info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,21 @@ This repository contains a collection of tools and commands used for managing th
 
   The Nitro Enclaves kernel driver is currently available in the following distro kernels:
 
-  - Amazon Linux 2 v4.14 kernel starting with kernel-4.14.198-152.320.amzn2.x86_64
-  - Amazon Linux 2 v5.4 kernel starting with kernel-5.4.68-34.125.amzn2.x86_64
-  - Amazon Linux 2 v5.10+ kernel (e.g. kernel-5.10.29-27.128.amzn2.x86_64)
-  - Ubuntu v5.4 kernel starting with linux-aws 5.4.0-1030-aws x86_64
-  - Ubuntu v5.8 kernel starting with linux-aws 5.8.0-1017-aws x86_64
-  - Ubuntu v5.11+ kernel (e.g. linux-aws 5.11.0-1006-aws x86_64)
-  - Fedora v5.10+ kernel (e.g. 5.10.12-200.fc33.x86_64)
-  - CentOS Stream v4.18+ kernel starting with kernel-4.18.0-257.el8.x86_64
-  - Red Hat Enterprise Linux v4.18+ kernel starting with kernel-4.18.0-305.el8.x86_64
+  - x86_64
+      - Amazon Linux 2 v4.14 kernel starting with kernel-4.14.198-152.320.amzn2.x86_64
+      - Amazon Linux 2 v5.4 kernel starting with kernel-5.4.68-34.125.amzn2.x86_64
+      - Amazon Linux 2 v5.10+ kernel (e.g. kernel-5.10.29-27.128.amzn2.x86_64)
+      - Ubuntu v5.4 kernel starting with linux-aws 5.4.0-1030-aws x86_64
+      - Ubuntu v5.8 kernel starting with linux-aws 5.8.0-1017-aws x86_64
+      - Ubuntu v5.11+ kernel (e.g. linux-aws 5.11.0-1006-aws x86_64)
+      - Fedora v5.10+ kernel (e.g. 5.10.12-200.fc33.x86_64)
+      - CentOS Stream v4.18+ kernel starting with kernel-4.18.0-257.el8.x86_64
+      - Red Hat Enterprise Linux v4.18+ kernel starting with kernel-4.18.0-305.el8.x86_64
+
+  - aarch64
+      - Amazon Linux 2 v4.14 kernel starting with kernel-4.14.252-195.483.amzn2.aarch64
+      - Amazon Linux 2 v5.4 kernel starting with kernel-5.4.156-83.273.amzn2.aarch64
+      - Amazon Linux 2 v5.10+ kernel starting with kernel-5.10.75-79.358.amzn2.aarch64
 
   The following packages need to be installed or updated to have the Nitro Enclaves kernel driver available in the mentioned distros:
 


### PR DESCRIPTION
The Nitro Enclaves kernel driver is available in the Amazon Linux 2
v4.14, v5.4 and v5.10 Linux kernels for aarch64. Add this info to the
list of distros that have integrated the NE kernel driver.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
