### PR TITLE
README: Update Nitro Enclaves kernel driver availability info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This repository contains a collection of tools and commands used for managing th
       - Amazon Linux 2022 v5.10+ kernel starting with kernel-5.10.75-82.359.amzn2022.aarch64
       - CentOS Stream v4.18 kernel starting with kernel-4.18.0-358.el8.aarch64
       - CentOS Stream v5.14+ kernel starting with kernel-5.14.0-24.el9.aarch64
+      - Ubuntu v5.4 kernel starting with linux-aws 5.4.0-1064-aws aarch64
+      - Ubuntu v5.13+ kernel starting with linux-aws 5.13.0-1012-aws aarch64
 
   The following packages need to be installed or updated to have the Nitro Enclaves kernel driver available in the mentioned distros:
 


### PR DESCRIPTION
The Nitro Enclaves kernel driver is available in the Ubuntu v5.4 and
v5.13+ Linux kernels for aarch64.

Add this info to the list of distros that have integrated the Nitro
Enclaves kernel driver.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
