### PR TITLE
Update ubuntu_20.04_how_to_install_nitro_cli_from_github_sources.md

### DIFF
--- a/docs/ubuntu_20.04_how_to_install_nitro_cli_from_github_sources.md
+++ b/docs/ubuntu_20.04_how_to_install_nitro_cli_from_github_sources.md
@@ -36,15 +36,15 @@ $ sudo apt-get install build-essential
 $ uname -r
 5.11.0-1016-aws
 
-$ grep /boot/config-5.11.0-1016-aws -e NITRO_ENCLAVES
+$ grep /boot/config-$(uname -r) -e NITRO_ENCLAVES
 CONFIG_NITRO_ENCLAVES=m
 
 $ sudo apt-get install linux-modules-extra-aws
 
-$ ls -l /usr/lib/modules/5.11.0-1016-aws/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
+$  ls -l /usr/lib/modules/$(uname -r)/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
 -rw-r--r-- 1 root root 63825 Aug 12 04:21 /usr/lib/modules/5.11.0-1016-aws/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
 
-$ sudo insmod /usr/lib/modules/5.11.0-1016-aws/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
+$ sudo insmod /usr/lib/modules/$(uname -r)/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
 
 $ lsmod | grep nitro_enclaves
 nitro_enclaves         45056  0


### PR DESCRIPTION
Adjusting the kernel version in the commands:
```
grep /boot/config-5.11.0-1016-aws -e NITRO_ENCLAVES
ls -l /usr/lib/modules/5.11.0-1016-aws/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
sudo insmod /usr/lib/modules/5.11.0-1016-aws/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
```

To use the nested `$(uname -r)` command instead; for easier copying and pasting. The callout above regarding different kernel versions (`The path to the driver can be updated depending on the kernel version installed on the system `) is still a good warning as the output will be different for each kernel version.

*Issue #, if available:*

*Description of changes:*
Adding $(uname -r) in place of kernel version in example commands for easier copy/paste. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
