### PR TITLE
Update centos_stream_8_how_to_install_nitro_cli_from_github_sources.md

### DIFF
--- a/docs/centos_stream_8_how_to_install_nitro_cli_from_github_sources.md
+++ b/docs/centos_stream_8_how_to_install_nitro_cli_from_github_sources.md
@@ -33,7 +33,7 @@ $ sudo dnf groupinstall "Development Tools"
 $ uname -r
 4.18.0-257.el8.x86_64
 
-$ grep /boot/config-4.18.0-257.el8.x86_64 -e NITRO_ENCLAVES
+$ grep /boot/config-$(uname -r) -e NITRO_ENCLAVES
 CONFIG_NITRO_ENCLAVES=m
 
 $ lsmod | grep nitro_enclaves


### PR DESCRIPTION
Updating `$ grep /boot/config-4.18.0-257.el8.x86_64 -e NITRO_ENCLAVES`
 to 
`$ grep /boot/config-$(uname -r) -e NITRO_ENCLAVES`

*Issue #, if available:*
Sorry for the flood of PRs, not entirely sure how to combine them all into one yet. 
*Description of changes:*
```
Updating `$ grep /boot/config-4.18.0-257.el8.x86_64 -e NITRO_ENCLAVES`
 to 
`$ grep /boot/config-$(uname -r) -e NITRO_ENCLAVES`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
