### PR TITLE
Update fedora_34_how_to_install_nitro_cli_from_github_sources.md

### DIFF
--- a/docs/fedora_34_how_to_install_nitro_cli_from_github_sources.md
+++ b/docs/fedora_34_how_to_install_nitro_cli_from_github_sources.md
@@ -41,7 +41,7 @@ $ sudo dnf groupinstall "Development Tools"
 $ uname -r
 5.13.13-200.fc34.x86_64
 
-$ grep /boot/config-5.13.13-200.fc34.x86_64 -e NITRO_ENCLAVES
+$ grep /boot/config-$(uname -r) -e NITRO_ENCLAVES
 CONFIG_NITRO_ENCLAVES=m
 
 $ lsmod | grep nitro_enclaves


### PR DESCRIPTION
Updating `$ grep /boot/config-5.13.13-200.fc34.x86_64 -e NITRO_ENCLAVES` 
To
`$ grep /boot/config-$(uname -r) -e NITRO_ENCLAVES`

*Issue #, if available:*
 Sorry for the flood of PRs, not entirely sure how to combine them all into one yet.
*Description of changes:*
```
Updating `$ grep /boot/config-5.13.13-200.fc34.x86_64 -e NITRO_ENCLAVES` 
To
`$ grep /boot/config-$(uname -r) -e NITRO_ENCLAVES`

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
