### PR TITLE
docs: Remove additional whitespace from a "ls" command in Ubuntu docs

### DIFF
--- a/docs/ubuntu_20.04_how_to_install_nitro_cli_from_github_sources.md
+++ b/docs/ubuntu_20.04_how_to_install_nitro_cli_from_github_sources.md
@@ -41,7 +41,7 @@ CONFIG_NITRO_ENCLAVES=m
 
 $ sudo apt-get install linux-modules-extra-aws
 
-$  ls -l /usr/lib/modules/$(uname -r)/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
+$ ls -l /usr/lib/modules/$(uname -r)/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
 -rw-r--r-- 1 root root 63825 Aug 12 04:21 /usr/lib/modules/5.11.0-1016-aws/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko
 
 $ sudo insmod /usr/lib/modules/$(uname -r)/kernel/drivers/virt/nitro_enclaves/nitro_enclaves.ko


### PR DESCRIPTION
Remove the additional whitespace from a "ls" command in the Ubuntu
documentation for installing Nitro CLI from GitHub sources.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
