### PR TITLE
nitro-cli: Update version of regex crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -3192,7 +3192,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.24</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.36</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.14</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex 1.5.4</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex 1.5.5</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.6.25</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash 1.1.0</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.6</a></li>


### PR DESCRIPTION
Fix the following error by updating to the latest version of the regex
crate:

Crate:         regex
Version:       1.5.4
Title:         Regexes with large repetitions on empty sub-expressions take a very long time to parse
Date:          2022-03-08
ID:            RUSTSEC-2022-0013
URL:           https://rustsec.org/advisories/RUSTSEC-2022-0013
Solution:      Upgrade to >=1.5.5
Dependency tree:
regex 1.5.4
├── flexi_logger 0.15.12
│   └── nitro-cli 1.2.0
├── env_logger 0.9.0
├── env_logger 0.7.1
└── bindgen 0.59.2
    └── nitro-cli 1.2.0

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #359*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
