### PR TITLE
nitro-cli: Remove custom metadata structure restriction for EIF images

### DIFF
--- a/eif_utils/src/identity.rs
+++ b/eif_utils/src/identity.rs
@@ -78,17 +78,5 @@ pub fn parse_custom_metadata(path: &str) -> Result<serde_json::Value, String> {
     let json_value: serde_json::Value = serde_json::from_reader(custom_file)
         .map_err(|e| format!("Failed to deserialize json: {}", e))?;
 
-    // Check json format, all keys and values should be: "String": "String"
-    let json_map = match json_value.as_object() {
-        Some(map) => map.to_owned(),
-        None => return Err("JSON does not respect format String:String".to_string()),
-    };
-
-    for (_key, value) in json_map {
-        if !value.is_string() {
-            return Err("JSON does not respect format String:String".to_string());
-        }
-    }
-
     Ok(json_value)
 }


### PR DESCRIPTION
The restrictions on string values and flat structure was unnecessary and is removed.

Example output:
```
$> cat custom.json
{
    "AppVersion": "3.0",
    "TestField": "Some info",
    "CustomInfo": "Added by user",
    "ArrayField": [
      {
        "id": 0,
        "name": "Value0"
      },
      {
        "id": 1,
        "name": "Value1"
      },
      {
        "id": 42,
        "name": "Value42"
      }
    ]
}

$> nitro-cli build-enclave --docker-uri hello:latest --output-file hello.eif --name="my_image" --version="3.35" --metadata custom.json
Start building the Enclave Image...
Using the locally available Docker image...
Enclave Image successfully created.
{
  "Measurements": {
    "HashAlgorithm": "Sha384 { ... }",
    "PCR0": "a0a09ef11c121dc943bb41bd60219f367847b667992c7a9c38969f5b2b5afcd9b8dd5c7471f1c14965f06ae13798275e",
    "PCR1": "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f",
    "PCR2": "3e0f7c0cf4cd2c23e52f5979f50485028eb8fdda9edd19dd2ed5eb7695c6ff974a3dca8afce122af59de5aeb8c6e10d5"
  }
}

$> nitro-cli describe-eif --eif-path hello.eif
{
  "EifVersion": 4,
  "Measurements": {
    "HashAlgorithm": "Sha384 { ... }",
    "PCR0": "a0a09ef11c121dc943bb41bd60219f367847b667992c7a9c38969f5b2b5afcd9b8dd5c7471f1c14965f06ae13798275e",
    "PCR1": "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f",
    "PCR2": "3e0f7c0cf4cd2c23e52f5979f50485028eb8fdda9edd19dd2ed5eb7695c6ff974a3dca8afce122af59de5aeb8c6e10d5"
  },
  "IsSigned": false,
  "CheckCRC": true,
  "ImageName": "my_image",
  "ImageVersion": "3.35",
  "Metadata": {
    "BuildTime": "2022-03-21T09:09:18.366741420+00:00",
    "BuildTool": "nitro-cli",
    "BuildToolVersion": "1.2.0",
    "OperatingSystem": "Linux",
    "KernelVersion": "4.14.256",
    "DockerInfo": {
      "Architecture": "amd64",
      "Author": "",
      "Comment": "",
      "Config": {
        "AttachStderr": false,
        "AttachStdin": false,
        "AttachStdout": false,
        "Cmd": [
          "/bin/hello.sh"
        ],
        "Domainname": "",
        "Entrypoint": null,
        "Env": [
          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
          "HELLO=Hello from the enclave side!"
        ],
        "ExposedPorts": null,
        "Hostname": "",
        "Image": "sha256:a560e320d01e4f3906105a76695a6904400149df6fb4af0c6c6f516e1901c345",
        "Labels": null,
        "OnBuild": null,
        "OpenStdin": false,
        "StdinOnce": false,
        "Tty": false,
        "User": "",
        "WorkingDir": ""
      },
      "Created": "2022-01-26T14:03:20.060242482Z",
      "DockerVersion": "20.10.7",
      "Id": "sha256:ff0e83ee92c92ff0b5e4810e500e4937d40109c81907635e894fe197b84c7491",
      "Os": "linux",
      "Parent": "sha256:a560e320d01e4f3906105a76695a6904400149df6fb4af0c6c6f516e1901c345",
      "RepoDigests": [],
      "RepoTags": [
        "hello:latest"
      ],
      "Size": 1240041,
      "VirtualSize": 1240041
    },
    "AppVersion": "3.0",
    "ArrayField": [
      {
        "id": 0,
        "name": "Value0"
      },
      {
        "id": 1,
        "name": "Value1"
      },
      {
        "id": 42,
        "name": "Value42"
      }
    ],
    "CustomInfo": "Added by user",
    "TestField": "Some info"
  }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
