### PR TITLE
Typos in the step-4 nitro-cli run-enclave command

### DIFF
--- a/samples/command_executer/README.md
+++ b/samples/command_executer/README.md
@@ -45,7 +45,7 @@ instance you are about to run an enclave on.
 4. Launch an enclave with the EIF containing command-executer.
 
 ```
-	$ ./nitro-cli run-enclave --cpu-count 4 --memory 2048 --eif-path command_executer.eif --enclave-cid 16
+	$ nitro-cli run-enclave --cpu-count 4 --memory 2048 --eif-path command-executer.eif --enclave-cid 16
 	Start allocating memory...
 	Started enclave with enclave-cid: 16, memory: 2048 MiB, cpu-ids: [1, 5, 2, 6]
 	{


### PR DESCRIPTION
command-executor.eif has a underscore instead of hyphen.
nitro-cli command is resolvable at the prompt, no need to include './'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
