### PR TITLE
README: Update Nitro Enclaves kernel driver availability info

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository contains a collection of tools and commands used for managing th
       - CentOS Stream v4.18 kernel starting with kernel-4.18.0-358.el8.aarch64
       - CentOS Stream v5.14+ kernel starting with kernel-5.14.0-24.el9.aarch64
       - Fedora v5.16+ kernel (e.g. kernel-5.16.5-200.fc35.aarch64)
+      - Red Hat Enterprise Linux v4.18+ kernel starting with kernel-4.18.0-372.9.1.el8.aarch64
       - Ubuntu v5.4 kernel starting with linux-aws 5.4.0-1064-aws aarch64
       - Ubuntu v5.13+ kernel starting with linux-aws 5.13.0-1012-aws aarch64
 


### PR DESCRIPTION
The Nitro Enclaves kernel driver is available in the RHEL v4.18+
Linux kernels for aarch64, starting with 4.18.0-372.9.1.el8.aarch64.

Add this info to the list of distros that have integrated the Nitro
Enclaves kernel driver.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
