### PR TITLE
shiplift: Proper usage of DOCKER_HOST env variable

### DIFF
--- a/enclave_build/src/docker.rs
+++ b/enclave_build/src/docker.rs
@@ -7,7 +7,6 @@ use log::{debug, error, info};
 use serde_json::{json, Value};
 use shiplift::RegistryAuth;
 use shiplift::{BuildOptions, Docker, PullOptions};
-use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -39,22 +38,6 @@ pub struct DockerUtil {
 impl DockerUtil {
     /// Constructor that takes as argument a tag for the docker image to be used
     pub fn new(docker_image: String) -> Self {
-        // Try to parse the DOCKER_HOST environment variable.
-        let host = match env::var("DOCKER_HOST") {
-            Ok(docker_host) => match docker_host.parse() {
-                Ok(host) => Some(host),
-                Err(_) => None,
-            },
-            Err(_) => None,
-        };
-
-        // If DOCKER_HOST could not be parsed, default to
-        // using 'unix:///var/run/docker.sock'.
-        let docker = match host {
-            Some(host) => Docker::host(host),
-            None => Docker::unix("/var/run/docker.sock"),
-        };
-
         let mut docker_image = docker_image;
 
         if !docker_image.contains(':') {
@@ -62,7 +45,10 @@ impl DockerUtil {
         }
 
         DockerUtil {
-            docker,
+            // DOCKER_HOST environment variable is parsed inside
+            // if docker daemon address needs to be substituted.
+            // By default it tries to connect to 'unix:///var/run/docker.sock'
+            docker: Docker::new(),
             docker_image,
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-nitro-enclaves-cli/issues/235

*Description of changes:*
`shiplift` library parses `DOCKER_HOST` environment variable internally.
User can forward it to another docker-compatible URL
(`unix:///var/run/docker.sock` by default).

Wrapper code we used around `shiplift` is redundant and repeats `shiplift`'s
internal implementation but without considering that specified URL
can point to any unix socket in a format of `unix:///socket/path`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
