### PR TITLE
Allow NITRO_CLI_INSTALL_DIR be set for path to allocator.yaml

### DIFF
--- a/bootstrap/nitro-enclaves-allocator
+++ b/bootstrap/nitro-enclaves-allocator
@@ -12,7 +12,7 @@ CPU_POOL_FILE="/sys/module/nitro_enclaves/parameters/ne_cpus"
 VERBOSE="1"
 
 # Path to the allocator config file.
-CONFIG_FILE_PATH="/etc/nitro_enclaves/allocator.yaml"
+CONFIG_FILE_PATH="$NITRO_CLI_INSTALL_DIR/etc/nitro_enclaves/allocator.yaml"
 
 # Config variables to be populated when parsing the config file.
 declare -A CONFIG


### PR DESCRIPTION
*Issue #, if available:* N/A


*Description of changes:*
When compiling the project, `NITRO_CLI_INSTALL_DIR` is used to direct where to copy and install the relevant files. In the [Ubuntu compilation guide](https://github.com/aws/aws-nitro-enclaves-cli/blob/main/docs/ubuntu_20.04_how_to_install_nitro_cli_from_github_sources.md), it is set as `NITRO_CLI_INSTALL_DIR=/`. 

At Stripe, we compile EIFs using `nitro-cli` in our CI systems and run EIFs via `nitro-cli` on other hosts. The directory layout of the nitro-cli tooling is different in CI than it is on our live systems. We've been setting `NITRO_CLI_INSTALL_DIR` to handle this. For example, `NITRO_CLI_INSTALL_DIR=/build` in CI and `NITRO_CLI_INSTALL_DIR=/deploy` when it is deployed on our live hosts. 

We encountered an issue in doing this as some of the tooling assumes `NITRO_CLI_INSTALL_DIR=/` and hard-codes paths to installed files. In this case, the `CONFIG_FILE_PATH` in `bootstrap/nitro-enclaves-allocator`. In this PR, I prepend `$NITRO_CLI_INSTALL_DIR` to that path so we can control where the configuration lives on disk, depending on the host. 

If `$NITRO_CLI_INSTALL_DIR` is not set, this is backwards compatible with existing path. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
