### PR TITLE
Allow NITRO_CLI_INSTALL_DIR to be overriden in nitro-cli-env.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ install: install-tools nitro_enclaves
                ${NITRO_CLI_INSTALL_DIR}/lib/modules/$(uname -r)/extra/nitro_enclaves/nitro_enclaves.ko
 	$(INSTALL) -D -m 0644 bootstrap/env.sh ${NITRO_CLI_INSTALL_DIR}${ENV_SETUP_DIR}/nitro-cli-env.sh
 	$(INSTALL) -D -m 0755 bootstrap/nitro-cli-config ${NITRO_CLI_INSTALL_DIR}${ENV_SETUP_DIR}/nitro-cli-config
-	sed -i "2 a NITRO_CLI_INSTALL_DIR=$$(readlink -f ${NITRO_CLI_INSTALL_DIR})" \
+	sed -i "2 a NITRO_CLI_INSTALL_DIR=\$${NITRO_CLI_INSTALL_DIR:-$$(readlink -f ${NITRO_CLI_INSTALL_DIR})}" \
 		${NITRO_CLI_INSTALL_DIR}${ENV_SETUP_DIR}/nitro-cli-env.sh
 	echo "Installation finished"
 	echo "Please run \"source ${NITRO_CLI_INSTALL_DIR}${ENV_SETUP_DIR}/nitro-cli-env.sh\" to setup the environment or add it your local shell configuration"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Similar to https://github.com/aws/aws-nitro-enclaves-cli/pull/376, there are a few cases where `NITRO_CLI_INSTALL_DIR` is fixed to a particular path when it should be adjustable. In this case, when compiling `aws-nitro-enclaves-cli`, the makefile command 

```
sed -i "2 a NITRO_CLI_INSTALL_DIR=$$(readlink -f ${NITRO_CLI_INSTALL_DIR})" \
		${NITRO_CLI_INSTALL_DIR}${ENV_SETUP_DIR}/nitro-cli-env.sh
```

injects the current `NITRO_CLI_INSTALL_DIR` value to the `nitro-cli-env.sh` file. 


At Stripe, we compile `aws-nitro-enclaves-cli` from source in CI and later deploy the binaries and configuration files to live hosts. The `NITRO_CLI_INSTALL_DIR` is different in our CI systems than it is on our live hosts. For example, `NITRO_CLI_INSTALL_DIR=/build/aws-nitro-enclaves-cli` in CI and `NITRO_CLI_INSTALL_DIR=/deploy` on live hosts. We ran into the issue of the hardcoded `NITRO_CLI_INSTALL_DIR` variable on live hosts when trying to prepare running an Enclave on them. 

To fix this, this PR modifies the injected statement to allow for an existing `NITRO_CLI_INSTALL_DIR` to be used instead. The prepared version of `nitro-cli-env.sh` now starts like:
```
#!/bin/bash

NITRO_CLI_INSTALL_DIR=${NITRO_CLI_INSTALL_DIR:-/build/aws-nitro-enclaves-cli}
```
This allows an existing `NITRO_CLI_INSTALL_DIR` to be respected, while maintaining a fallback to the build-time value if not set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
