### PR TITLE
command-executer: Switch to package instead of workspace 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tempfile = "3.1"
 
 [workspace]
 members = [".", "driver-bindings", "eif_loader", "enclave_build", "vsock_proxy"]
+exclude = ["samples/command_executer"]
 
 [features]
 default = []

--- a/samples/command_executer/Cargo.toml
+++ b/samples/command_executer/Cargo.toml
@@ -16,5 +16,3 @@ byteorder = "1.3"
 num = "0.2"
 num-derive = "0.3"
 num-traits = "0.2"
-
-[workspace]


### PR DESCRIPTION
This commit allows users to build command-executer in two ways:
1. via plain cargo build
   --manifest-path=samples/command_executer/Cargo.toml like we do in our
   Makefile
2. from the nitro-cli workspace by declaring it as a member in
   Cargo.toml

To keep the nitro-cli build as it was before, we add
samples/command_executer to the exclude array of the workspace.

Signed-off-by: Sabin Rapan <sabrapan@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
