### PR TITLE
workflows: fix repository name in summary

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -24,11 +24,13 @@ jobs:
           gh issue list --json title,updatedAt,labels,assignees,url --template \
             '{{ printf "URL\tTitle\tLast updated\n"}}{{range .}}{{printf "%s\t%s\t%s\n" .url .title (timeago .updatedAt)}}{{end}}' | column -ts $'\t' >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+
+          # Fetch repository name and store it to
+          # REPOSITORY_NAME environment variable
+          echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
       - name: notify
         run: |
           # Send open PRs and issues lists from corresponding environment variables to a dedicated webhook URL
-          curl -d '{ "repo": "${{ github.event.repository.name }}", "prs": "${{ env.PRS_CONTENT }}", "issues": "${{ env.ISSUES_CONTENT }}" }' ${{ secrets.SUMMARY_WEBHOOK_URL }}
+          curl -d '{ "repo": "${{ env.REPOSITORY_NAME }}", "prs": "${{ env.PRS_CONTENT }}", "issues": "${{ env.ISSUES_CONTENT }}" }' ${{ secrets.SUMMARY_WEBHOOK_URL }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
github.event is empty in case of sceduled workflows.
Repository name should be fetched through github.repository variable instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
