### PR TITLE
Update Rust version to 1.58.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.2.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
+rust-version = "1.58"
 
 [dependencies]
 serde = { version = ">=1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![msrv]
+
+[msrv]: https://img.shields.io/badge/MSRV-1.58.1-blue
+
 ## Nitro Enclaves Command Line Interface (Nitro CLI)
 
 This repository contains a collection of tools and commands used for managing the lifecycle of enclaves. The Nitro CLI needs to be installed on the parent instance, and it can be used to start, manage, and terminate enclaves.  

--- a/driver-bindings/Cargo.toml
+++ b/driver-bindings/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 description = "Rust FFI bindings to Linux Nitro Enclaves driver generated using bindgen."
+rust-version = "1.58"

--- a/eif_loader/Cargo.toml
+++ b/eif_loader/Cargo.toml
@@ -3,6 +3,7 @@ name = "eif_loader"
 version = "0.1.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
+rust-version = "1.58"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/enclave_build/Cargo.toml
+++ b/enclave_build/Cargo.toml
@@ -3,6 +3,7 @@ name = "enclave_build"
 version = "0.1.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
+rust-version = "1.58"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/samples/command_executer/Cargo.toml
+++ b/samples/command_executer/Cargo.toml
@@ -3,6 +3,7 @@ name = "command-executer"
 version = "0.1.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
+rust-version = "1.58"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tools/Dockerfile1804.aarch64
+++ b/tools/Dockerfile1804.aarch64
@@ -28,7 +28,7 @@ RUN unzip /openssl_src/${OPENSSL_VERSION}.zip -d /openssl_src
 RUN cd /openssl_src/openssl-${OPENSSL_VERSION} && CC=musl-gcc CFLAGS=-fPIC ./Configure --prefix=/musl_openssl --openssldir=/musl_openssl no-shared no-engine no-afalgeng linux-aarch64 -DOPENSSL_NO_SECURE_MEMORY && make && make install
 
 # Setup the right rust ver
-ENV RUST_VERSION=1.49.0
+ENV RUST_VERSION=1.58.1
 RUN  source $HOME/.cargo/env && \
      rustup toolchain install ${RUST_VERSION}-aarch64-unknown-linux-gnu
 RUN  source $HOME/.cargo/env && \

--- a/tools/Dockerfile1804.x86_64
+++ b/tools/Dockerfile1804.x86_64
@@ -28,7 +28,7 @@ RUN unzip /openssl_src/${OPENSSL_VERSION}.zip -d /openssl_src
 RUN cd /openssl_src/openssl-${OPENSSL_VERSION} && CC=musl-gcc CFLAGS=-fPIC ./Configure --prefix=/musl_openssl --openssldir=/musl_openssl no-shared no-engine no-afalgeng linux-x86_64 -DOPENSSL_NO_SECURE_MEMORY && make && make install
 
 # Setup the right rust ver
-ENV RUST_VERSION=1.49.0
+ENV RUST_VERSION=1.58.1
 RUN  source $HOME/.cargo/env && \
      rustup toolchain install ${RUST_VERSION}-x86_64-unknown-linux-gnu
 RUN  source $HOME/.cargo/env && \

--- a/vsock_proxy/Cargo.toml
+++ b/vsock_proxy/Cargo.toml
@@ -3,6 +3,7 @@ name = "vsock-proxy"
 version = "0.1.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
+rust-version = "1.58"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
*Issue #, if available:*
Crates with edition 2021 were not compiling because support for this edition was added with Rust 1.56

*Description of changes:*
- Updated RUST_VERSION ENV variable to 1.58.1 in aarch64 and x86_64 Dockerfiles
- Added Rust version 1.58 to all Cargo.toml files
- Added MSRV 1.58.1 badge to README


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
