### PR TITLE
eif_loader: Fix clippy warning (clippy::derive_partial_eq_without_eq)

### DIFF
--- a/eif_loader/src/lib.rs
+++ b/eif_loader/src/lib.rs
@@ -18,7 +18,7 @@ pub const TIMEOUT_MINUTE_MS: i32 = 90 * TIMEOUT_SECOND_MS;
 
 const HEART_BEAT: u8 = 0xB7;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 /// Internal errors while sending an Eif file
 pub enum EifLoaderError {
     SocketPollingError,


### PR DESCRIPTION
error: you are deriving `PartialEq` and can implement `Eq`
  --> eif_loader/src/lib.rs:21:17
   |
21 | #[derive(Debug, PartialEq)]
   |                 ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
   |
note: the lint level is defined here
  --> eif_loader/src/lib.rs:3:9
   |
3  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(clippy::derive_partial_eq_without_eq)]` implied by `#[deny(warnings)]`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
error: could not compile `eif_loader` due to previous error

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
