### PR TITLE
cpu_info: mock input in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,16 +105,8 @@ driver-deps:
 	echo "Warning: kernel-header were not installed") \
 	&& echo "Successfully installed the driver deps"
 
-# In order to avoid executing the same rule everytime,
-# the build rules are prefixed by dot and are generating
-# a file with the same name via the touch command. This
-# change is required in order to capture the timestamp
-# of the rule.
-.build-container: tools/Dockerfile1804.${HOST_MACHINE}
-	docker image build -t $(CONTAINER_TAG) -f tools/Dockerfile1804.${HOST_MACHINE} tools/
-	touch $@
-
-build-container: .build-container
+build-container:
+	@docker image build --pull --quiet -t $(CONTAINER_TAG) -f tools/Dockerfile1804.${HOST_MACHINE} tools/
 
 $(OBJ_PATH):
 	$(MKDIR) -p $(OBJ_PATH)

--- a/tools/Dockerfile1804.aarch64
+++ b/tools/Dockerfile1804.aarch64
@@ -36,11 +36,9 @@ RUN  source $HOME/.cargo/env && \
 RUN  source $HOME/.cargo/env && \
     rustup target add --toolchain ${RUST_VERSION} aarch64-unknown-linux-musl
 RUN  source $HOME/.cargo/env && \
-     rustup toolchain install 1.57-aarch64-unknown-linux-gnu
+    cargo install cargo-audit --version 0.16.0 --locked
 RUN  source $HOME/.cargo/env && \
-    cargo +1.57 install cargo-audit --version 0.16.0 --locked
-RUN  source $HOME/.cargo/env && \
-    cargo +1.57 install cargo-about --version 0.4.3 --locked
+    cargo install cargo-about --version 0.5.1 --locked
 RUN apt-get install -y jq
 
 # Install docker for nitro-cli build-enclave runs

--- a/tools/Dockerfile1804.aarch64
+++ b/tools/Dockerfile1804.aarch64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y clang
 
 # Build static version of Openssl.
 RUN apt-get install -y wget unzip
-ENV OPENSSL_VERSION=OpenSSL_1_1_1l
+ENV OPENSSL_VERSION=OpenSSL_1_1_1q
 RUN mkdir /openssl_src
 RUN wget https://github.com/openssl/openssl/archive/${OPENSSL_VERSION}.zip -P /openssl_src
 RUN unzip /openssl_src/${OPENSSL_VERSION}.zip -d /openssl_src

--- a/tools/Dockerfile1804.x86_64
+++ b/tools/Dockerfile1804.x86_64
@@ -36,11 +36,9 @@ RUN  source $HOME/.cargo/env && \
 RUN  source $HOME/.cargo/env && \
     rustup target add --toolchain ${RUST_VERSION} x86_64-unknown-linux-musl
 RUN  source $HOME/.cargo/env && \
-     rustup toolchain install 1.57-x86_64-unknown-linux-gnu
+	cargo install cargo-audit --version 0.16.0 --locked
 RUN  source $HOME/.cargo/env && \
-	cargo +1.57 install cargo-audit --version 0.16.0 --locked
-RUN  source $HOME/.cargo/env && \
-	cargo +1.57 install cargo-about --version 0.4.3 --locked
+	cargo install cargo-about --version 0.5.1 --locked
 RUN apt-get install -y jq
 
 # Install docker for nitro-cli build-enclave runs

--- a/tools/Dockerfile1804.x86_64
+++ b/tools/Dockerfile1804.x86_64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y clang
 
 # Build static version of Openssl.
 RUN apt-get install -y wget unzip
-ENV OPENSSL_VERSION=OpenSSL_1_1_1l
+ENV OPENSSL_VERSION=OpenSSL_1_1_1q
 RUN mkdir /openssl_src
 RUN wget https://github.com/openssl/openssl/archive/${OPENSSL_VERSION}.zip -P /openssl_src
 RUN unzip /openssl_src/${OPENSSL_VERSION}.zip -d /openssl_src


### PR DESCRIPTION
To allow cpu_info unit tests to run even on systems without Nitro
Enclaves, or with Nitro Enclaves in a different configuration, allow
reading CpuInfo from a BufRead, to mock the expected output.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
