### PR TITLE
kunit: fix Kconfig for build-in tests USB4 and Nitro Enclaves

### DIFF
--- a/drivers/virt/nitro_enclaves/Kconfig
+++ b/drivers/virt/nitro_enclaves/Kconfig
@@ -17,7 +17,7 @@ config NITRO_ENCLAVES
 
 config NITRO_ENCLAVES_MISC_DEV_TEST
 	bool "Tests for the misc device functionality of the Nitro Enclaves" if !KUNIT_ALL_TESTS
-	depends on NITRO_ENCLAVES && KUNIT
+	depends on NITRO_ENCLAVES && KUNIT=y
 	default KUNIT_ALL_TESTS
 	help
 	  Enable KUnit tests for the misc device functionality of the Nitro


### PR DESCRIPTION
Both the USB4 and Nitro Enclaves KUNIT tests are now able to be compiled if KUNIT is compiled as a module. This leads to issues if KUNIT is being packaged separately from the core kernel and when KUNIT is run baremetal without the required driver compiled into the kernel.

Fixes: 635dcd16844b ("thunderbolt: test: Use kunit_test_suite() macro")
Fixes: fe5be808fa6c ("nitro_enclaves: test: Use kunit_test_suite() macro")
Signed-off-by: Nico Pache <npache@redhat.com>
Reviewed-by: David Gow <davidgow@google.com>
Reviewed-by: Andra Paraschiv <andraprs@amazon.com>
Acked-by: Brendan Higgins <brendanhiggins@google.com>
Signed-off-by: Shuah Khan <skhan@linuxfoundation.org>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
