### PR TITLE
sources: Update nitro-cli-dependencies.tar.gz to include all crates d…

### DIFF
--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-e3bac0b52a34864c0d3a425dea02f37dd8d6c6c4  nitro-cli-dependencies.tar.gz
+536f0b4c4e9c9687bb93be980918f00e63fb9b45  nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
…ependencies

The previous version of nitro-cli-dependencies.tar.gz didn't include all the crates dependencies needed by nitro-cli. Update it to the latest generated version.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
