### PR TITLE
aws-nitro-enclaves-cli.spec: Update minimum required Rust version

### DIFF
--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -28,8 +28,8 @@ Source0: aws-nitro-enclaves-cli.tar.gz
 Source1: nitro-cli-dependencies.tar.gz
 
 BuildRequires: openssl-devel
-BuildRequires: rust >= 1.47
-BuildRequires: cargo >= 1.47
+BuildRequires: rust >= 1.58
+BuildRequires: cargo >= 1.58
 BuildRequires: make
 BuildRequires: llvm
 BuildRequires: clang


### PR DESCRIPTION
The Rust version has been updated to 1.58 in the Cargo.toml files for nitro-cli.

Modify the minimum required Rust version in the spec file to be 1.58.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
