### PR TITLE
enclave_build: Error refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "sha2",
  "shiplift",
  "tempfile",
+ "thiserror",
  "tokio",
  "url",
 ]

--- a/enclave_build/Cargo.toml
+++ b/enclave_build/Cargo.toml
@@ -20,5 +20,6 @@ log = "0.4"
 url = "2.1"
 sha2 = "0.9.5"
 futures = "0.3.13"
+thiserror = "1.0"
 
 aws-nitro-enclaves-image-format = "0.2"

--- a/enclave_build/src/docker.rs
+++ b/enclave_build/src/docker.rs
@@ -1,15 +1,13 @@
 // Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::docker::DockerError::CredentialsError;
+use crate::{EnclaveBuildError, Result};
 use futures::stream::StreamExt;
-use log::{debug, error, info};
+use log::{debug, info};
 use serde_json::{json, Value};
 use shiplift::RegistryAuth;
 use shiplift::{BuildOptions, Docker, PullOptions};
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
+use std::{fs::File, io::Write, path::Path};
 use tempfile::NamedTempFile;
 use tokio::runtime::Runtime;
 use url::Url;
@@ -17,17 +15,6 @@ use url::Url;
 /// Docker inspect architecture constants
 pub const DOCKER_ARCH_ARM64: &str = "arm64";
 pub const DOCKER_ARCH_AMD64: &str = "amd64";
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum DockerError {
-    BuildError,
-    InspectError,
-    PullError,
-    RuntimeError,
-    TempfileError,
-    CredentialsError(String),
-    UnsupportedEntryPoint,
-}
 
 /// Struct exposing the Docker functionalities to the EIF builder
 pub struct DockerUtil {
@@ -59,7 +46,7 @@ impl DockerUtil {
     /// we are parsing it correctly, so the parsing mechanism had been infered by
     /// reading a config.json created by:
     //         Docker version 19.03.2
-    fn get_credentials(&self) -> Result<RegistryAuth, DockerError> {
+    fn get_credentials(&self) -> Result<RegistryAuth> {
         let image = self.docker_image.clone();
         let host = if let Ok(uri) = Url::parse(&image) {
             uri.host().map(|s| s.to_string())
@@ -77,11 +64,18 @@ impl DockerUtil {
         if let Some(registry_domain) = host {
             let config_file = self.get_config_file()?;
 
-            let config_json: serde_json::Value = serde_json::from_reader(&config_file)
-                .map_err(|err| CredentialsError(format!("JSON was not well-formatted: {}", err)))?;
+            let config_json: serde_json::Value =
+                serde_json::from_reader(&config_file).map_err(|err| {
+                    EnclaveBuildError::CredentialsError(format!(
+                        "JSON was not well-formatted: {}",
+                        err
+                    ))
+                })?;
 
             let auths = config_json.get("auths").ok_or_else(|| {
-                CredentialsError("Could not find auths key in config JSON".to_string())
+                EnclaveBuildError::CredentialsError(
+                    "Could not find auths key in config JSON".to_string(),
+                )
             })?;
 
             if let Value::Object(auths) = auths {
@@ -93,16 +87,24 @@ impl DockerUtil {
                     let auth = registry_auths
                         .get("auth")
                         .ok_or_else(|| {
-                            CredentialsError("Could not find auth key in config JSON".to_string())
+                            EnclaveBuildError::CredentialsError(
+                                "Could not find auth key in config JSON".to_string(),
+                            )
                         })?
                         .to_string();
 
                     let auth = auth.replace('"', "");
                     let decoded = base64::decode(&auth).map_err(|err| {
-                        CredentialsError(format!("Invalid Base64 encoding for auth: {}", err))
+                        EnclaveBuildError::CredentialsError(format!(
+                            "Invalid Base64 encoding for auth: {}",
+                            err
+                        ))
                     })?;
                     let decoded = std::str::from_utf8(&decoded).map_err(|err| {
-                        CredentialsError(format!("Invalid utf8 encoding for auth: {}", err))
+                        EnclaveBuildError::CredentialsError(format!(
+                            "Invalid utf8 encoding for auth: {}",
+                            err
+                        ))
                     })?;
 
                     if let Some(index) = decoded.rfind(':') {
@@ -117,15 +119,15 @@ impl DockerUtil {
             }
         }
 
-        Err(CredentialsError(
+        Err(EnclaveBuildError::CredentialsError(
             "No credentials found for the current image".to_string(),
         ))
     }
 
-    fn get_config_file(&self) -> Result<File, DockerError> {
+    fn get_config_file(&self) -> Result<File> {
         if let Ok(file) = std::env::var("DOCKER_CONFIG") {
             let config_file = File::open(file).map_err(|err| {
-                DockerError::CredentialsError(format!(
+                EnclaveBuildError::CredentialsError(format!(
                     "Could not open file pointed by env\
                      DOCKER_CONFIG: {}",
                     err
@@ -138,7 +140,7 @@ impl DockerUtil {
                 let config_path = Path::new(&default_config_path);
                 if config_path.exists() {
                     let config_file = File::open(config_path).map_err(|err| {
-                        DockerError::CredentialsError(format!(
+                        EnclaveBuildError::CredentialsError(format!(
                             "Could not open file {:?}: {}",
                             config_path.to_str(),
                             err
@@ -147,7 +149,7 @@ impl DockerUtil {
                     return Ok(config_file);
                 }
             }
-            Err(DockerError::CredentialsError(
+            Err(EnclaveBuildError::CredentialsError(
                 "Config file not present, please set env \
                  DOCKER_CONFIG accordingly"
                     .to_string(),
@@ -156,7 +158,7 @@ impl DockerUtil {
     }
 
     /// Pull the image, with the tag provided in constructor, from the Docker registry
-    pub fn pull_image(&self) -> Result<(), DockerError> {
+    pub fn pull_image(&self) -> Result<()> {
         let act = async {
             // Check if the Docker image is locally available.
             // If available, early exit.
@@ -196,15 +198,13 @@ impl DockerUtil {
                             let msg = &output;
 
                             if let Some(err_msg) = msg.get("error") {
-                                error!("{:?}", err_msg.clone());
-                                break Err(DockerError::PullError);
+                                break Err(EnclaveBuildError::ImagePullError(err_msg.to_string()));
                             } else {
                                 info!("{}", msg);
                             }
                         }
                         Err(e) => {
-                            error!("{:?}", e);
-                            break Err(DockerError::PullError);
+                            break Err(EnclaveBuildError::ImagePullError(e.to_string()));
                         }
                     }
                 } else {
@@ -213,14 +213,14 @@ impl DockerUtil {
             }
         };
 
-        let runtime = Runtime::new().map_err(|_| DockerError::RuntimeError)?;
+        let runtime = Runtime::new().map_err(|_| EnclaveBuildError::RuntimeError)?;
 
         runtime.block_on(act)
     }
 
     /// Build an image locally, with the tag provided in constructor, using a
     /// directory that contains a Dockerfile
-    pub fn build_image(&self, dockerfile_dir: String) -> Result<(), DockerError> {
+    pub fn build_image(&self, dockerfile_dir: String) -> Result<()> {
         let act = async {
             let mut stream = self.docker.images().build(
                 &BuildOptions::builder(dockerfile_dir)
@@ -235,15 +235,13 @@ impl DockerUtil {
                             let msg = &output;
 
                             if let Some(err_msg) = msg.get("error") {
-                                error!("{:?}", err_msg.clone());
-                                break Err(DockerError::BuildError);
+                                break Err(EnclaveBuildError::ImageBuildError(err_msg.to_string()));
                             } else {
                                 info!("{}", msg);
                             }
                         }
                         Err(e) => {
-                            error!("{:?}", e);
-                            break Err(DockerError::BuildError);
+                            break Err(EnclaveBuildError::ImageBuildError(e.to_string()));
                         }
                     }
                 } else {
@@ -252,53 +250,44 @@ impl DockerUtil {
             }
         };
 
-        let runtime = Runtime::new().map_err(|_| DockerError::RuntimeError)?;
+        let runtime = Runtime::new().map_err(|_| EnclaveBuildError::RuntimeError)?;
 
         runtime.block_on(act)
     }
 
     /// Inspect docker image and return its description as a json String
-    pub fn inspect_image(&self) -> Result<serde_json::Value, DockerError> {
+    pub fn inspect_image(&self) -> Result<serde_json::Value> {
         let act = async {
             match self.docker.images().get(&self.docker_image).inspect().await {
                 Ok(image) => Ok(json!(image)),
-                Err(e) => {
-                    error!("{:?}", e);
-                    Err(DockerError::InspectError)
-                }
+                Err(e) => Err(EnclaveBuildError::ImageInspectError(e)),
             }
         };
 
-        let runtime = Runtime::new().map_err(|_| DockerError::RuntimeError)?;
+        let runtime = Runtime::new().map_err(|_| EnclaveBuildError::RuntimeError)?;
         runtime.block_on(act)
     }
 
-    fn extract_image(&self) -> Result<(Vec<String>, Vec<String>), DockerError> {
+    fn extract_image(&self) -> Result<(Vec<String>, Vec<String>)> {
         // First try to find CMD parameters (together with potential ENV bindings)
         let act_cmd = async {
             match self.docker.images().get(&self.docker_image).inspect().await {
-                Ok(image) => image.config.cmd.ok_or(DockerError::UnsupportedEntryPoint),
-                Err(e) => {
-                    error!("{:?}", e);
-                    Err(DockerError::InspectError)
-                }
+                Ok(image) => image.config.cmd.ok_or(EnclaveBuildError::EntrypointError),
+                Err(e) => Err(EnclaveBuildError::ImageInspectError(e)),
             }
         };
         let act_env = async {
             match self.docker.images().get(&self.docker_image).inspect().await {
-                Ok(image) => image.config.env.ok_or(DockerError::UnsupportedEntryPoint),
-                Err(e) => {
-                    error!("{:?}", e);
-                    Err(DockerError::InspectError)
-                }
+                Ok(image) => image.config.env.ok_or(EnclaveBuildError::EntrypointError),
+                Err(e) => Err(EnclaveBuildError::ImageInspectError(e)),
             }
         };
 
         let check_cmd_runtime = Runtime::new()
-            .map_err(|_| DockerError::RuntimeError)?
+            .map_err(|_| EnclaveBuildError::RuntimeError)?
             .block_on(act_cmd);
         let check_env_runtime = Runtime::new()
-            .map_err(|_| DockerError::RuntimeError)?
+            .map_err(|_| EnclaveBuildError::RuntimeError)?
             .block_on(act_env);
 
         // If no CMD instructions are found, try to locate an ENTRYPOINT command
@@ -308,20 +297,17 @@ impl DockerUtil {
                     Ok(image) => image
                         .config
                         .entrypoint
-                        .ok_or(DockerError::UnsupportedEntryPoint),
-                    Err(e) => {
-                        error!("{:?}", e);
-                        Err(DockerError::InspectError)
-                    }
+                        .ok_or(EnclaveBuildError::EntrypointError),
+                    Err(e) => Err(EnclaveBuildError::ImageInspectError(e)),
                 }
             };
 
             let check_entrypoint_runtime = Runtime::new()
-                .map_err(|_| DockerError::RuntimeError)?
+                .map_err(|_| EnclaveBuildError::RuntimeError)?
                 .block_on(act_entrypoint);
 
             if check_entrypoint_runtime.is_err() {
-                return Err(DockerError::UnsupportedEntryPoint);
+                return Err(EnclaveBuildError::EntrypointError);
             }
 
             let act = async {
@@ -330,14 +316,11 @@ impl DockerUtil {
                         image.config.entrypoint.unwrap(),
                         image.config.env.ok_or_else(Vec::<String>::new).unwrap(),
                     )),
-                    Err(e) => {
-                        error!("{:?}", e);
-                        Err(DockerError::InspectError)
-                    }
+                    Err(e) => Err(EnclaveBuildError::ImageInspectError(e)),
                 }
             };
 
-            let runtime = Runtime::new().map_err(|_| DockerError::RuntimeError)?;
+            let runtime = Runtime::new().map_err(|_| EnclaveBuildError::RuntimeError)?;
 
             return runtime.block_on(act);
         }
@@ -345,14 +328,11 @@ impl DockerUtil {
         let act = async {
             match self.docker.images().get(&self.docker_image).inspect().await {
                 Ok(image) => Ok((image.config.cmd.unwrap(), image.config.env.unwrap())),
-                Err(e) => {
-                    error!("{:?}", e);
-                    Err(DockerError::InspectError)
-                }
+                Err(e) => Err(EnclaveBuildError::ImageInspectError(e)),
             }
         };
 
-        let runtime = Runtime::new().map_err(|_| DockerError::RuntimeError)?;
+        let runtime = Runtime::new().map_err(|_| EnclaveBuildError::RuntimeError)?;
 
         runtime.block_on(act)
     }
@@ -360,7 +340,7 @@ impl DockerUtil {
     /// The main function of this struct. This needs to be called in order to
     /// extract the necessary configuration values from the docker image with
     /// the tag provided in the constructor
-    pub fn load(&self) -> Result<(NamedTempFile, NamedTempFile), DockerError> {
+    pub fn load(&self) -> Result<(NamedTempFile, NamedTempFile)> {
         let (cmd, env) = self.extract_image()?;
 
         let cmd_file = write_config(cmd)?;
@@ -370,29 +350,26 @@ impl DockerUtil {
     }
 
     /// Fetch architecture information from an image
-    pub fn architecture(&self) -> Result<String, DockerError> {
+    pub fn architecture(&self) -> Result<String> {
         let arch = async {
             match self.docker.images().get(&self.docker_image).inspect().await {
                 Ok(image) => Ok(image.architecture),
-                Err(e) => {
-                    error!("{:?}", e);
-                    Err(DockerError::InspectError)
-                }
+                Err(e) => Err(EnclaveBuildError::ImageInspectError(e)),
             }
         };
 
-        let runtime = Runtime::new().map_err(|_| DockerError::RuntimeError)?;
+        let runtime = Runtime::new().map_err(|_| EnclaveBuildError::RuntimeError)?;
 
         runtime.block_on(arch)
     }
 }
 
-fn write_config(config: Vec<String>) -> Result<NamedTempFile, DockerError> {
-    let mut file = NamedTempFile::new().map_err(|_| DockerError::TempfileError)?;
+fn write_config(config: Vec<String>) -> Result<NamedTempFile> {
+    let mut file = NamedTempFile::new().map_err(|_| EnclaveBuildError::ConfigError)?;
 
     for line in config {
         file.write_fmt(format_args!("{}\n", line))
-            .map_err(|_| DockerError::TempfileError)?;
+            .map_err(|_| EnclaveBuildError::ConfigError)?;
     }
 
     Ok(file)

--- a/enclave_build/src/lib.rs
+++ b/enclave_build/src/lib.rs
@@ -12,7 +12,7 @@ mod yaml_generator;
 use aws_nitro_enclaves_image_format::defs::{EifBuildInfo, EifIdentityInfo, EIF_HDR_ARCH_ARM64};
 use aws_nitro_enclaves_image_format::utils::identity::parse_custom_metadata;
 use aws_nitro_enclaves_image_format::utils::{EifBuilder, SignEnclaveInfo};
-use docker::{DockerError, DockerUtil};
+use docker::DockerUtil;
 use serde_json::json;
 use sha2::Digest;
 use std::collections::BTreeMap;
@@ -23,14 +23,16 @@ pub const DEFAULT_TAG: &str = "1.0";
 
 #[derive(Debug, Error)]
 pub enum EnclaveBuildError {
-    #[error("Docker error: `{0:?}`")]
-    DockerError(DockerError),
+    #[error("Docker error: `{0}`")]
+    DockerError(String),
     #[error("Invalid path: `{0}`")]
     PathError(String),
     #[error("Image pull error: `{0}`")]
     ImagePullError(String),
-    #[error("Image inspect failed")]
-    ImageInspectError,
+    #[error("Container image build error: `{0}`")]
+    ImageBuildError(String),
+    #[error("Image inspect failed: `{0:?}`")]
+    ImageInspectError(shiplift::Error),
     #[error("Linuxkit error: `{0}`")]
     LinuxKitError(String),
     #[error("File operation error: `{0:?}`")]
@@ -162,10 +164,7 @@ impl<'a> Docker2Eif<'a> {
     }
 
     pub fn pull_docker_image(&self) -> Result<()> {
-        self.docker.pull_image().map_err(|e| {
-            eprintln!("Docker error: {:?}", e);
-            EnclaveBuildError::DockerError(e)
-        })?;
+        self.docker.pull_image()?;
 
         Ok(())
     }
@@ -174,19 +173,13 @@ impl<'a> Docker2Eif<'a> {
         if !Path::new(&dockerfile_dir).is_dir() {
             return Err(EnclaveBuildError::PathError(dockerfile_dir));
         }
-        self.docker.build_image(dockerfile_dir).map_err(|e| {
-            eprintln!("Docker error: {:?}", e);
-            EnclaveBuildError::DockerError(e)
-        })?;
+        self.docker.build_image(dockerfile_dir)?;
 
         Ok(())
     }
 
     fn generate_identity_info(&self) -> Result<EifIdentityInfo> {
-        let docker_info = self
-            .docker
-            .inspect_image()
-            .map_err(EnclaveBuildError::DockerError)?;
+        let docker_info = self.docker.inspect_image()?;
 
         let uri_split: Vec<&str> = self.docker_image.split(':').collect();
         if uri_split.is_empty() {
@@ -233,10 +226,7 @@ impl<'a> Docker2Eif<'a> {
     }
 
     pub fn create(&mut self) -> Result<BTreeMap<String, String>> {
-        let (cmd_file, env_file) = self.docker.load().map_err(|e| {
-            eprintln!("Docker error: {:?}", e);
-            EnclaveBuildError::DockerError(e)
-        })?;
+        let (cmd_file, env_file) = self.docker.load()?;
 
         let yaml_generator = YamlGenerator::new(
             self.docker_image.clone(),
@@ -306,10 +296,7 @@ impl<'a> Docker2Eif<'a> {
             )));
         }
 
-        let arch = self.docker.architecture().map_err(|e| {
-            eprintln!("Docker error: {:?}", e);
-            EnclaveBuildError::DockerError(e)
-        })?;
+        let arch = self.docker.architecture()?;
 
         let flags = match arch.as_str() {
             docker::DOCKER_ARCH_ARM64 => EIF_HDR_ARCH_ARM64,

--- a/enclave_build/src/lib.rs
+++ b/enclave_build/src/lib.rs
@@ -12,13 +12,70 @@ mod yaml_generator;
 use aws_nitro_enclaves_image_format::defs::{EifBuildInfo, EifIdentityInfo, EIF_HDR_ARCH_ARM64};
 use aws_nitro_enclaves_image_format::utils::identity::parse_custom_metadata;
 use aws_nitro_enclaves_image_format::utils::{EifBuilder, SignEnclaveInfo};
-use docker::DockerUtil;
+use docker::{DockerError, DockerUtil};
 use serde_json::json;
 use sha2::Digest;
 use std::collections::BTreeMap;
-use yaml_generator::YamlGenerator;
+use thiserror::Error;
+use yaml_generator::{YamlGenerator, YamlGeneratorError};
 
 pub const DEFAULT_TAG: &str = "1.0";
+
+#[derive(Debug, Error)]
+pub enum EnclaveBuildError {
+    #[error("Docker error: `{0:?}`")]
+    DockerError(DockerError),
+    #[error("Invalid path: `{0}`")]
+    PathError(String),
+    #[error("Image pull error: `{0}`")]
+    ImagePullError(String),
+    #[error("Image inspect failed")]
+    ImageInspectError,
+    #[error("Linuxkit error: `{0}`")]
+    LinuxKitError(String),
+    #[error("File operation error: `{0:?}`")]
+    FileError(std::io::Error),
+    #[error("Ramfs error: `{0:?}`")]
+    RamfsError(YamlGeneratorError),
+    #[error("Signature error: `{0}`")]
+    SignError(String),
+    #[error("Metadata error: `{0}`")]
+    MetadataError(String),
+    #[error("Unsupported architecture")]
+    UnsupportedArchError,
+    #[error("Getting image detail failed: `{0}`")]
+    ImageDetailError(String),
+    #[error("Container image operation failed")]
+    ImageOperationError,
+    #[error("Failed to convert image to EIF")]
+    ImageConvertError,
+    #[error("Hashing error: `{0}`")]
+    HashingError(String),
+    #[error("Serde error: `{0:?}`")]
+    SerdeError(serde_json::Error),
+    #[error("Error while parsing credentials: `{0}`")]
+    CredentialsError(String),
+    #[error("Image cache initialization error: `{0:?}`")]
+    CacheInitError(std::io::Error),
+    #[error("Cache store operation failed: `{0:?}`")]
+    CacheStoreError(std::io::Error),
+    #[error("Cache entry not found or has wrong: `{0:?}`")]
+    CacheMissError(String),
+    #[error("Manifest missing or wrong format")]
+    ConfigError,
+    #[error("Manifest missing or wrong format")]
+    ManifestError,
+    #[error("Failed to extract expressions from image: `{0}`")]
+    ExtractError(String),
+    #[error("Image entrypoint missing or unsupported")]
+    EntrypointError,
+    #[error("Runtime creation failed")]
+    RuntimeError,
+    #[error("EIF build error: `{0}`")]
+    OtherError(String),
+}
+
+pub type Result<T> = std::result::Result<T, EnclaveBuildError>;
 
 pub struct Docker2Eif<'a> {
     docker_image: String,
@@ -37,26 +94,6 @@ pub struct Docker2Eif<'a> {
     build_info: EifBuildInfo,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum Docker2EifError {
-    DockerError,
-    DockerfilePathError,
-    ImagePullError,
-    InitPathError,
-    NsmPathError,
-    KernelPathError,
-    LinuxkitExecError,
-    LinuxkitPathError,
-    MetadataPathError,
-    MetadataError(String),
-    ArtifactsPrefixError,
-    RamfsError,
-    RemoveFileError,
-    SignImageError(String),
-    SignArgsError,
-    UnsupportedArchError,
-}
-
 impl<'a> Docker2Eif<'a> {
     pub fn new(
         docker_image: String,
@@ -73,34 +110,37 @@ impl<'a> Docker2Eif<'a> {
         img_version: Option<String>,
         metadata_path: Option<String>,
         build_info: EifBuildInfo,
-    ) -> Result<Self, Docker2EifError> {
+    ) -> Result<Self> {
         let docker = DockerUtil::new(docker_image.clone());
+        let blob_paths = Vec::from([&init_path, &nsm_path, &kernel_img_path, &linuxkit_path]);
 
-        if !Path::new(&init_path).is_file() {
-            return Err(Docker2EifError::InitPathError);
-        } else if !Path::new(&nsm_path).is_file() {
-            return Err(Docker2EifError::NsmPathError);
-        } else if !Path::new(&kernel_img_path).is_file() {
-            return Err(Docker2EifError::KernelPathError);
-        } else if !Path::new(&linuxkit_path).is_file() {
-            return Err(Docker2EifError::LinuxkitPathError);
-        } else if !Path::new(&artifacts_prefix).is_dir() {
-            return Err(Docker2EifError::ArtifactsPrefixError);
+        blob_paths.iter().try_for_each(|path| {
+            if !Path::new(path).is_file() {
+                return Err(EnclaveBuildError::PathError(path.to_string()));
+            }
+            Ok(())
+        })?;
+
+        if !Path::new(&artifacts_prefix).is_dir() {
+            return Err(EnclaveBuildError::PathError(artifacts_prefix));
         }
 
         if let Some(ref path) = metadata_path {
             if !Path::new(path).is_file() {
-                return Err(Docker2EifError::MetadataPathError);
+                return Err(EnclaveBuildError::PathError(path.to_string()));
             }
         }
 
         let sign_info = match (certificate_path, key_path) {
             (None, None) => None,
             (Some(cert_path), Some(key_path)) => Some(
-                SignEnclaveInfo::new(cert_path, key_path)
-                    .map_err(|err| Docker2EifError::SignImageError(format!("{:?}", err)))?,
+                SignEnclaveInfo::new(cert_path, key_path).map_err(EnclaveBuildError::SignError)?,
             ),
-            _ => return Err(Docker2EifError::SignArgsError),
+            _ => {
+                return Err(EnclaveBuildError::SignError(
+                    "Invalid signing arguments".to_string(),
+                ))
+            }
         };
 
         Ok(Docker2Eif {
@@ -121,35 +161,36 @@ impl<'a> Docker2Eif<'a> {
         })
     }
 
-    pub fn pull_docker_image(&self) -> Result<(), Docker2EifError> {
+    pub fn pull_docker_image(&self) -> Result<()> {
         self.docker.pull_image().map_err(|e| {
             eprintln!("Docker error: {:?}", e);
-            Docker2EifError::DockerError
+            EnclaveBuildError::DockerError(e)
         })?;
 
         Ok(())
     }
 
-    pub fn build_docker_image(&self, dockerfile_dir: String) -> Result<(), Docker2EifError> {
+    pub fn build_docker_image(&self, dockerfile_dir: String) -> Result<()> {
         if !Path::new(&dockerfile_dir).is_dir() {
-            return Err(Docker2EifError::DockerfilePathError);
+            return Err(EnclaveBuildError::PathError(dockerfile_dir));
         }
         self.docker.build_image(dockerfile_dir).map_err(|e| {
             eprintln!("Docker error: {:?}", e);
-            Docker2EifError::DockerError
+            EnclaveBuildError::DockerError(e)
         })?;
 
         Ok(())
     }
 
-    fn generate_identity_info(&self) -> Result<EifIdentityInfo, Docker2EifError> {
-        let docker_info = self.docker.inspect_image().map_err(|e| {
-            Docker2EifError::MetadataError(format!("Docker inspect error: {:?}", e))
-        })?;
+    fn generate_identity_info(&self) -> Result<EifIdentityInfo> {
+        let docker_info = self
+            .docker
+            .inspect_image()
+            .map_err(EnclaveBuildError::DockerError)?;
 
         let uri_split: Vec<&str> = self.docker_image.split(':').collect();
         if uri_split.is_empty() {
-            return Err(Docker2EifError::MetadataError(
+            return Err(EnclaveBuildError::ImageDetailError(
                 "Wrong image name specified".to_string(),
             ));
         }
@@ -163,7 +204,7 @@ impl<'a> Docker2Eif<'a> {
             .and_then(|val| val.as_str())
             .and_then(|str| str.strip_prefix("sha256:"))
             .ok_or_else(|| {
-                Docker2EifError::MetadataError(
+                EnclaveBuildError::MetadataError(
                     "Image info must contain string Id field".to_string(),
                 )
             })?;
@@ -179,7 +220,7 @@ impl<'a> Docker2Eif<'a> {
 
         let mut custom_info = json!(null);
         if let Some(ref path) = self.metadata_path {
-            custom_info = parse_custom_metadata(path).map_err(Docker2EifError::MetadataError)?
+            custom_info = parse_custom_metadata(path).map_err(EnclaveBuildError::MetadataError)?
         }
 
         Ok(EifIdentityInfo {
@@ -191,10 +232,10 @@ impl<'a> Docker2Eif<'a> {
         })
     }
 
-    pub fn create(&mut self) -> Result<BTreeMap<String, String>, Docker2EifError> {
+    pub fn create(&mut self) -> Result<BTreeMap<String, String>> {
         let (cmd_file, env_file) = self.docker.load().map_err(|e| {
             eprintln!("Docker error: {:?}", e);
-            Docker2EifError::DockerError
+            EnclaveBuildError::DockerError(e)
         })?;
 
         let yaml_generator = YamlGenerator::new(
@@ -207,11 +248,11 @@ impl<'a> Docker2Eif<'a> {
 
         let ramfs_config_file = yaml_generator.get_bootstrap_ramfs().map_err(|e| {
             eprintln!("Ramfs error: {:?}", e);
-            Docker2EifError::RamfsError
+            EnclaveBuildError::RamfsError(e)
         })?;
         let ramfs_with_rootfs_config_file = yaml_generator.get_customer_ramfs().map_err(|e| {
             eprintln!("Ramfs error: {:?}", e);
-            Docker2EifError::RamfsError
+            EnclaveBuildError::RamfsError(e)
         })?;
 
         let bootstrap_ramfs = format!("{}/bootstrap-initrd.img", self.artifacts_prefix);
@@ -227,13 +268,16 @@ impl<'a> Docker2Eif<'a> {
                 ramfs_config_file.path().to_str().unwrap(),
             ])
             .output()
-            .map_err(|_| Docker2EifError::LinuxkitExecError)?;
+            .map_err(|e| EnclaveBuildError::LinuxKitError(format!("{:?}", e)))?;
         if !output.status.success() {
             eprintln!(
                 "Linuxkit reported an error while creating the bootstrap ramfs: {:?}",
                 String::from_utf8_lossy(&output.stderr)
             );
-            return Err(Docker2EifError::LinuxkitExecError);
+            return Err(EnclaveBuildError::LinuxKitError(format!(
+                "{:?}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
         }
 
         // Prefix the docker image filesystem, as expected by init
@@ -250,24 +294,29 @@ impl<'a> Docker2Eif<'a> {
                 ramfs_with_rootfs_config_file.path().to_str().unwrap(),
             ])
             .output()
-            .map_err(|_| Docker2EifError::LinuxkitExecError)?;
+            .map_err(|e| EnclaveBuildError::LinuxKitError(format!("{:?}", e)))?;
         if !output.status.success() {
             eprintln!(
                 "Linuxkit reported an error while creating the customer ramfs: {:?}",
                 String::from_utf8_lossy(&output.stderr)
             );
-            return Err(Docker2EifError::LinuxkitExecError);
+            return Err(EnclaveBuildError::LinuxKitError(format!(
+                "{:?}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
         }
 
         let arch = self.docker.architecture().map_err(|e| {
             eprintln!("Docker error: {:?}", e);
-            Docker2EifError::DockerError
+            EnclaveBuildError::DockerError(e)
         })?;
 
         let flags = match arch.as_str() {
             docker::DOCKER_ARCH_ARM64 => EIF_HDR_ARCH_ARM64,
             docker::DOCKER_ARCH_AMD64 => 0,
-            _ => return Err(Docker2EifError::UnsupportedArchError),
+            _ => {
+                return Err(EnclaveBuildError::UnsupportedArchError);
+            }
         };
 
         let mut build = EifBuilder::new(


### PR DESCRIPTION
Dockerless frature (1/5)

This is the first PR from splitting the initial one #404.

To avoid defining error types in each module file to be implemented for this feature, I created a general error type in the `lib.rs` file. In this way, the enclave build error can be used outside the crate and also extended easier.
By using `thiserror` attributes, we don't need display implementations for every defined error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
