### PR TITLE
enclave_build: Fix clippy warning (clippy::needless_borrow)

### DIFF
--- a/enclave_build/src/lib.rs
+++ b/enclave_build/src/lib.rs
@@ -218,7 +218,7 @@ impl<'a> Docker2Eif<'a> {
         let customer_ramfs = format!("{}/customer-initrd.img", self.artifacts_prefix);
 
         let output = Command::new(&self.linuxkit_path)
-            .args(&[
+            .args([
                 "build",
                 "-name",
                 &bootstrap_ramfs,
@@ -238,7 +238,7 @@ impl<'a> Docker2Eif<'a> {
 
         // Prefix the docker image filesystem, as expected by init
         let output = Command::new(&self.linuxkit_path)
-            .args(&[
+            .args([
                 "build",
                 "-docker",
                 "-name",


### PR DESCRIPTION
warning: the borrowed expression implements the required traits
   --> enclave_build/src/lib.rs:221:19
    |
221 |               .args(&[
    |  ___________________^
222 | |                 "build",
223 | |                 "-name",
224 | |                 &bootstrap_ramfs,
...   |
227 | |                 ramfs_config_file.path().to_str().unwrap(),
228 | |             ])
    | |_____________^
    |
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: the borrowed expression implements the required traits
   --> enclave_build/src/lib.rs:241:19
    |
241 |               .args(&[
    |  ___________________^
242 | |                 "build",
243 | |                 "-docker",
244 | |                 "-name",
...   |
250 | |                 ramfs_with_rootfs_config_file.path().to_str().unwrap(),
251 | |             ])
    | |_____________^
    |

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
