### PR TITLE
ci: add workflows build, clippy and format workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,13 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: rustup component add rustfmt
     - run: cargo fmt --all -- --check
+
+  audit:
+    name: Check dependencies for security issues
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo install --locked --version "~0.17" cargo-audit
+    - run: cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  build:
+    name: Test on rust ${{matrix.rust}}  (keys ${{ matrix.key_feature_set }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+          rust: [1.58.1, stable, nightly]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{matrix.rust}}
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo build --all --locked
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: rustup component add clippy
+    - run: cargo clippy --all
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: rustup component add rustfmt
+    - run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,30 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo install --locked --version "~0.17" cargo-audit
     - run: cargo audit --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071
+
+  license:
+    name: Check dependencies for licenses
+    runs-on: ubuntu-latest
+    outputs:
+      license_changed: ${{ steps.license_diff.outputs.license_changed }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo install --locked --version "~0.5" cargo-about
+    - run: cargo about generate --workspace --output-file "${{ runner.temp }}/licenses.html" about.hbs
+    - id: license_diff
+      run: |
+        if diff -q THIRD_PARTY_LICENSES_RUST_CRATES.html ${{ runner.temp }}/licenses.html ; then
+          echo "license_changed=NO" >> $GITHUB_OUTPUT
+        else
+          echo "license_changed=YES" >> $GITHUB_OUTPUT
+        fi
+
+  license_update:
+    name: Check if rust crates license files needs updates
+    runs-on: ubuntu-latest
+    needs: license
+    continue-on-error: true
+    steps:
+      - run: test "${{ needs.license.outputs.license_changed }}" == "NO"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -64,22 +64,6 @@ pytest-3 tests/integration/test_installation.py || test_failed
 # Clean up build artefacts
 make clean
 
-# Run 'cargo fmt'
-echo "=================== cargo fmt ========================="
-make nitro-format || test_failed
-
-# Run 'cargo clippy'
-echo "=================== cargo clippy ==========================="
-make nitro-clippy || test_failed
-
-# Run 'cargo audit'
-echo "=================== cargo audit ==========================="
-make nitro-audit || test_failed
-
-# Check Rust licenses
-echo "=================== cargo about ==========================="
-make nitro-about || test_failed
-
 # Setup the environement with everything needed to run the integration tests
 make command-executer || test_failed
 make nitro-tests || test_failed


### PR DESCRIPTION
Currently all the workflows are being run in a private environment and the results from this workflow are not being published, which makes it difficult for contributors to understand and fix the issues they might encounter. This adds a separate CI for build, format and clippy, which should add at least some observability. Some of the tests require a specific environment to run, so currently they cannot be enabled to run in the github workflow, I will filter out these tests separately and either fix them, where possible, or filter them out from the list of tests to run in the workflow in a future PR.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
