### PR TITLE
OCI storage

### DIFF
--- a/enclave_build/docs/storage.md
+++ b/enclave_build/docs/storage.md
@@ -1,0 +1,171 @@
+# Image Local Storage
+
+When building an enclave image using the Docker daemon, the image is pulled and stored in the
+Docker storage (place in the filesystem where images pulled from remote registries are saved locally).
+We want to implement the same functionality when choosing to build an OCI image.
+The resulted storage follows the [OCI specification](https://github.com/opencontainers/image-spec),
+allowing tools like `linuxkit` to use it as its own cache, and also adding images from OCI archive
+with the same format.
+
+To ease the interactions with the image details, the storage structure holds the config of the
+image used to build the EIF. This prevents unnecessary file reads.
+
+## Structure
+
+The root folder of the storage is either `${XDG_DATA_HOME}/.aws-nitro-enclaves-cli/container_storage`,
+or, if `XDG_DATA_HOME` is not set, `${HOME}/.local/share/.aws-nitro-enclaves-cli/container_storage`
+is used.
+
+The storage holds common components used by all images (index file, layout file, blobs folder) and
+individual items specific to the image named blobs (manifest, config file, layers). A possible
+storage structure can look like this:
+
+```
+storage_dir/
+|________index.json   -> points to the manifest blob file for each image (maps image reference to manifest digest)
+|________oci-layout
+|            blobs/sha256/
+|            |_______98806831de537d56f19b4b3cbf6ed80187374a1521a18d2d0c5f8a0e3962b2ae -> manifest_hash points to config and layers
+|            |_______feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412 -> config_hash
+|            |_______2db29710123e3e53a794f2694094b9b4338aa9ee5c40b930cb8063a1be392c54 -> layer_hash
+```
+
+### Examples
+
+To better understand the storage structure and how the index and manifest point to other files, we
+can follow a `hello-world` image example.
+
+#### Index
+
+index.json
+```
+{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 425,
+      "digest": "sha256:98806831de537d56f19b4b3cbf6ed80187374a1521a18d2d0c5f8a0e3962b2ae",
+      "annotations": {
+        "org.opencontainers.image.ref.name": "docker.io/test-oci:hello"
+      }
+    }
+  ]
+}
+```
+
+As we can see, the index holds one manifest entry, for one image stored. The number of manifests
+increases with each newly stored image. The manifest hash points us to the manifest blob.
+
+#### Layout file
+
+oci-layout:
+```
+{"imageLayoutVersion":"1.0.0"}
+```
+
+This file simply defines the OCI image layout version we are using.
+
+#### Manifest
+
+98806831de537d56f19b4b3cbf6ed80187374a1521a18d2d0c5f8a0e3962b2ae
+```
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+  "config": {
+    "mediaType": "application/vnd.docker.container.image.v1+json",
+    "digest": "sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412",
+    "size": 1469
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "digest": "sha256:2db29710123e3e53a794f2694094b9b4338aa9ee5c40b930cb8063a1be392c54",
+      "size": 2479
+    }
+  ]
+}
+```
+
+The manifest is our guide for a particular image. It tells us which components among the blobs
+belong to the image it defines. It tells us the digest of the content for the config file and each
+layer. With this information we can search the blobs.
+
+#### Config
+
+The configuration file defines the behavior of the image inside the container, platform
+dependencies and interaction with the filesystem composed from the layers. Nitro CLI's usage of
+the storage should not be concerned with the contents of this file (excepting UTF-8 and digest
+validation).
+
+#### Layers
+
+Layers are serialized filesystem changes that go on top of each other, starting from the base
+filesystem we create the image with. The file has binary content that, from Nitro CLI's point of
+view, just has to obey the content digest in the manifest.
+
+## Operations
+
+The operations offered by the `storage` module are as follows:
+
+### Create
+
+When building our first image, the storage does not exist. This operation creates, prior to
+storing an image, an empty storage. It contains the storage root folder and a blobs folder. Also
+at this point, the config of the current image is not yet loaded in the memory.
+
+### Store
+
+This is the operation which adds an image to the storage. It is called on an empty storage or after
+a fetch fails when searching for the image. After pulling the image and extracting its details, its
+manifest entry is added to the index and the blobs are written, each to their file.
+
+### Fetch details
+
+This operation returns the details of an image (image name, config digest and the config itself).
+These details are saved in the memory as the config of the image we are currently using to build
+the EIF. If a fetch was performed before, the config is already loaded and we can just return it.
+No other file read is needed.
+
+When we fetch an image without the config already loaded, we want to also check that it is stored
+correctly (or stored at all). The validation starts from the index file. It should contain our
+image's reference and the digest of the manifest. If fields are missing or the JSON structure does
+not comply, an error is returned.
+
+The validation continues with the manifest. As we did with the index, we validate the structure and
+get the digests for the config and blobs to later check them as well. We also check that the
+content of the manifest matches its digest from the file name.
+
+The config validation simply checks that a file with its content digest exists and the content is
+UTF-8 formatted. The file name is also validated against the content hash.
+
+Having a list of the layers' digest from the manifest, we go through each of them to get access to
+the blob files. By hashing each of the files and comparing the result with the initial digest, we
+validate the layers as well.
+
+
+### Get root folder
+
+So we can get access to the storage contents outside the `storage` module (in our case for
+`linuxkit`), we want to be able to return the location of the storage files. The module returns
+the root folder of the storage, as decided by the values of the environment variables
+`XDG_DATA_HOME` or `HOME`.
+
+## Workflow
+
+To see how these operations fit with each other and the structure as well, let's explore the common
+workflow:
+
+1. Given an image name we want to build an EIF
+2. Perform the first fetch:
+  - Check if the config of the current image is loaded. If it is, just return the image details
+  built from this config.
+  - If there is no config, read the files and perform the validation while searching for the
+  image files.
+  - If the validation hasn't failed, return the config.
+3. If the fetch failed (storage empty, missing our image, or malformed), pull the image from the
+remote registry, store its contents and load the config.
+4. A second fetch (for the inspect) returns the image details using the config from the memory
+without additional steps.
+

--- a/enclave_build/src/image.rs
+++ b/enclave_build/src/image.rs
@@ -71,7 +71,7 @@ pub fn deserialize_from_reader<R: Read, T: DeserializeOwned>(reader: R) -> Resul
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use oci_distribution::{
         client::{Config, ImageLayer},
@@ -80,10 +80,10 @@ mod tests {
 
     /// Name of the custom image to be used for testing the cache.
     /// This image will not be pulled from remote.
-    const TEST_IMAGE_NAME: &str = "hello-world";
+    pub const TEST_IMAGE_NAME: &str = "hello-world";
 
     /// The manifest.json of the image used for testing.
-    const TEST_MANIFEST: &str = r#"
+    pub const TEST_MANIFEST: &str = r#"
     {
         "schemaVersion":2,
         "mediaType":"application/vnd.docker.distribution.manifest.v2+json",
@@ -185,12 +185,12 @@ mod tests {
     "##;
 
     /// The hash of the test image calculated as the SHA256 digest of the image config
-    const TEST_IMAGE_HASH: &str =
+    pub const TEST_IMAGE_HASH: &str =
         "9f5747c1f734cb78bf90123f791324f2a75c75863f1b94a91051702aa87e9511";
 
     // Simple layers used for testing
-    const TEST_LAYER_1: &str = "Hello World 1";
-    const TEST_LAYER_2: &str = "Hello World 2";
+    pub const TEST_LAYER_1: &str = "Hello World 1";
+    pub const TEST_LAYER_2: &str = "Hello World 2";
 
     /// Builds a mock ImageData struct in order to avoid pulling it from remote.
     pub fn build_image_data() -> ImageData {

--- a/enclave_build/src/lib.rs
+++ b/enclave_build/src/lib.rs
@@ -66,6 +66,8 @@ pub enum EnclaveBuildError {
     OciStorageStore(std::io::Error),
     #[error("Storage entry not found or has wrong: `{0:?}`")]
     OciStorageNotFound(String),
+    #[error("Storage has the wrong structure: `{0:?}`")]
+    OciStorageMalformed(String),
     #[error("Manifest missing or wrong format")]
     ConfigError,
     #[error("Manifest missing or wrong format")]

--- a/enclave_build/src/lib.rs
+++ b/enclave_build/src/lib.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 mod docker;
 mod image;
 mod pull;
+mod storage;
 mod yaml_generator;
 
 use aws_nitro_enclaves_image_format::defs::{EifBuildInfo, EifIdentityInfo, EIF_HDR_ARCH_ARM64};
@@ -59,12 +60,12 @@ pub enum EnclaveBuildError {
     SerdeError(serde_json::Error),
     #[error("Error while parsing credentials: `{0}`")]
     CredentialsError(String),
-    #[error("Image cache initialization error: `{0:?}`")]
-    CacheInitError(std::io::Error),
-    #[error("Cache store operation failed: `{0:?}`")]
-    CacheStoreError(std::io::Error),
-    #[error("Cache entry not found or has wrong: `{0:?}`")]
-    CacheMissError(String),
+    #[error("Image storage initialization error: `{0:?}`")]
+    OciStorageInit(std::io::Error),
+    #[error("Image store operation failed: `{0:?}`")]
+    OciStorageStore(std::io::Error),
+    #[error("Storage entry not found or has wrong: `{0:?}`")]
+    OciStorageNotFound(String),
     #[error("Manifest missing or wrong format")]
     ConfigError,
     #[error("Manifest missing or wrong format")]

--- a/enclave_build/src/storage.rs
+++ b/enclave_build/src/storage.rs
@@ -2,13 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(dead_code)]
 use std::{
-    fs::{self},
+    collections::HashMap,
+    fs::{self, File},
+    io::{Error, ErrorKind, Read, Write},
     path::{Path, PathBuf},
 };
 
+use oci_distribution::{
+    client::ImageData,
+    manifest::{ImageIndexEntry, OciImageIndex, OciImageManifest, OCI_IMAGE_MEDIA_TYPE},
+};
+use serde_json::json;
+use sha2::Digest;
+
 use oci_spec::image::ImageConfiguration;
 
-use crate::{EnclaveBuildError, Result};
+use crate::{
+    image::{self, deserialize_from_reader},
+    EnclaveBuildError, Result,
+};
 
 /// Root folder for the image storage.
 const STORAGE_ROOT_FOLDER: &str = "XDG_DATA_HOME";
@@ -58,5 +70,316 @@ impl OciStorage {
             root_path: root_path.to_path_buf(),
             config: None,
         })
+    }
+
+    /// Stores the image data provided as argument in the storage at the folder pointed
+    /// by the 'root_path' field.
+    pub fn store_image_data(&mut self, image_name: &str, image_data: &ImageData) -> Result<()> {
+        // Create the folder where the image data will be stored. Each image blob will be stored in
+        // a file named by the SHA256 digest of the content.
+        let blobs_path = self.root_path.join(STORAGE_BLOBS_FOLDER);
+        fs::create_dir_all(&blobs_path).map_err(EnclaveBuildError::OciStorageStore)?;
+
+        // Each layer file will be named after the layer's digest hash
+        Self::store_layers(&blobs_path, image_data)?;
+
+        let manifest = Self::store_manifest(&blobs_path, image_data)?;
+
+        // Store the config and validate UTF8 bytes
+        let config_content = Self::store_config(&blobs_path, image_data)?;
+
+        // If index file present, read and append new image entry to the JSON list
+        self.store_index(image_name, manifest)?;
+
+        // Write oci_layout file from template constant
+        self.store_layout()?;
+
+        self.config = Some(deserialize_from_reader(config_content.as_bytes())?);
+
+        Ok(())
+    }
+
+    fn default_oci_index() -> OciImageIndex {
+        OciImageIndex {
+            schema_version: 2,
+            media_type: None,
+            manifests: Vec::new(),
+            annotations: None,
+        }
+    }
+
+    fn store_layers(blobs_path: &Path, image_data: &ImageData) -> Result<()> {
+        for layer in &image_data.layers {
+            Self::write_blob(blobs_path, &layer.data)?;
+        }
+
+        Ok(())
+    }
+
+    fn store_manifest<'a>(
+        blobs_path: &Path,
+        image_data: &'a ImageData,
+    ) -> Result<&'a OciImageManifest> {
+        let manifest = image_data
+            .manifest
+            .as_ref()
+            .ok_or(EnclaveBuildError::ManifestError)?;
+        let manifest_bytes = serde_json::to_vec(manifest).map_err(EnclaveBuildError::SerdeError)?;
+
+        Self::write_blob(blobs_path, &manifest_bytes)?;
+
+        Ok(manifest)
+    }
+
+    fn store_config(blobs_path: &Path, image_data: &ImageData) -> Result<String> {
+        let config_content = String::from_utf8(image_data.config.data.clone()).map_err(|_| {
+            EnclaveBuildError::OciStorageStore(Error::new(
+                ErrorKind::InvalidData,
+                "Config data invalid",
+            ))
+        })?;
+
+        Self::write_blob(blobs_path, config_content.as_bytes())?;
+
+        Ok(config_content)
+    }
+
+    fn store_index(&self, image_name: &str, manifest: &OciImageManifest) -> Result<()> {
+        let mut index_content: OciImageIndex = File::open(STORAGE_INDEX_FILE_NAME).map_or_else(
+            |_| Ok(Self::default_oci_index()),
+            |file| serde_json::from_reader(file).map_err(EnclaveBuildError::SerdeError),
+        )?;
+        let image_ref =
+            Self::normalize_reference(&image::build_image_reference(image_name)?.whole());
+
+        // Create manifest entry in the index file
+        let manifest_bytes = serde_json::to_vec(manifest).map_err(EnclaveBuildError::SerdeError)?;
+        let new_manifest = ImageIndexEntry {
+            media_type: manifest
+                .media_type
+                .as_ref()
+                .unwrap_or(&OCI_IMAGE_MEDIA_TYPE.to_string())
+                .to_string(),
+            digest: Self::blob_hash(&manifest_bytes),
+            size: manifest_bytes.len() as i64,
+            platform: None,
+            annotations: Some(HashMap::from([(REF_ANNOTATION.to_string(), image_ref)])),
+        };
+
+        // If all image data was successfully stored, add the image to the index file
+        index_content.manifests.push(new_manifest);
+        let index_file = File::options()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(self.root_path.join(STORAGE_INDEX_FILE_NAME))
+            .map_err(EnclaveBuildError::OciStorageStore)?;
+
+        // Write index file content
+        serde_json::to_writer(index_file, &index_content).map_err(EnclaveBuildError::SerdeError)?;
+
+        Ok(())
+    }
+
+    fn store_layout(&self) -> Result<()> {
+        let layout_content = json!(HashMap::from([OCI_LAYOUT]));
+
+        let layout_file = File::options()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(self.root_path.join(STORAGE_OCI_LAYOUT_FILE))
+            .map_err(EnclaveBuildError::OciStorageStore)?;
+
+        serde_json::to_writer(layout_file, &layout_content)
+            .map_err(EnclaveBuildError::SerdeError)?;
+
+        Ok(())
+    }
+
+    fn write_blob(blobs_path: &Path, bytes: &[u8]) -> Result<()> {
+        let digest = format!("{:x}", sha2::Sha256::digest(bytes));
+
+        File::options()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(blobs_path.join(digest))
+            .map_err(EnclaveBuildError::OciStorageStore)?
+            .write_all(bytes)
+            .map_err(EnclaveBuildError::OciStorageStore)?;
+
+        Ok(())
+    }
+
+    /// Fetch index file from the storage root path
+    fn fetch_index(root_path: &Path) -> Result<OciImageIndex> {
+        match File::open(root_path.join(STORAGE_INDEX_FILE_NAME)) {
+            Ok(file) => serde_json::from_reader(file).map_err(EnclaveBuildError::SerdeError),
+            Err(err) => Err(EnclaveBuildError::OciStorageNotFound(format!(
+                "Index file missing: {:?}",
+                err
+            ))),
+        }
+    }
+
+    /// Returns manifest from blob, given the digest
+    fn fetch_manifest(root_path: &Path, manifest_hash: &str) -> Result<OciImageManifest> {
+        let digest = manifest_hash
+            .strip_prefix("sha256:")
+            .ok_or(EnclaveBuildError::ManifestError)?;
+        let target_path = root_path.join(STORAGE_BLOBS_FOLDER);
+
+        // Read the JSON string from the stored manifest file
+        let manifest_path = target_path.join(digest);
+        let file = File::open(&manifest_path).map_err(|_| EnclaveBuildError::ManifestError)?;
+        let manifest: OciImageManifest =
+            serde_json::from_reader(file).map_err(EnclaveBuildError::SerdeError)?;
+
+        Ok(manifest)
+    }
+
+    /// Returns the config JSON string from the storage
+    fn fetch_config(root_path: &Path, config_digest: &str) -> Result<ImageConfiguration> {
+        let target_path = root_path.join(STORAGE_BLOBS_FOLDER);
+
+        let mut config_json = String::new();
+        File::open(target_path.join(config_digest))
+            .map_err(|_| EnclaveBuildError::ConfigError)?
+            .read_to_string(&mut config_json)
+            .map_err(|_| EnclaveBuildError::ConfigError)?;
+
+        if config_json.is_empty() {
+            return Err(EnclaveBuildError::ConfigError);
+        }
+
+        deserialize_from_reader(config_json.as_bytes())
+    }
+
+    /// Add `docker.io` to references that are missing this registry. `Linuxkit` will search
+    /// for images in the index file by automatically appending `docker.io` to their reference.
+    /// To prevent `linuxkit` from pulling the image again (with a reference that doesn't exist),
+    /// we want to save them the same way they will be searched.
+    fn normalize_reference(reference: &str) -> String {
+        let docker_prefix = "docker.io/";
+        if reference.starts_with(docker_prefix) {
+            return reference.to_string();
+        }
+
+        docker_prefix.to_owned() + reference
+    }
+
+    /// Format image blobs' hashes as represented in the storage files
+    fn blob_hash(bytes: &[u8]) -> String {
+        format!("sha256:{:x}", sha2::Sha256::digest(bytes))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use oci_distribution::manifest::OciImageManifest;
+    use vmm_sys_util::tempdir::TempDir;
+
+    /// This function stores the test image in a temporary directory and returns that directory and
+    /// the storage manager initialized with it as root path.
+    fn setup_temp_storage() -> (TempDir, OciStorage) {
+        // Use a temporary dir as the storage root path
+        // Create temporary random path so tests running in parallel won't overlap
+        let root_dir = TempDir::new().unwrap();
+
+        fs::create_dir_all(&root_dir.as_path()).unwrap();
+
+        // Use a mock ImageData struct
+        let image_data = image::tests::build_image_data();
+
+        // Initialize the storage structure
+        let mut storage =
+            OciStorage::new(&root_dir.as_path()).expect("failed to create the OciStorage");
+
+        // Store the mock image data in the temp storage
+        storage
+            .store_image_data(image::tests::TEST_IMAGE_NAME, &image_data)
+            .expect("failed to store test image to storage");
+
+        (root_dir, storage)
+    }
+
+    #[test]
+    fn test_fetch_index() {
+        let (root_dir, _storage) = setup_temp_storage();
+        let root_path = root_dir.as_path();
+
+        let index = OciStorage::fetch_index(&root_path).expect("Failed to fetch index.json");
+        let index = json!(index);
+
+        let manifest: OciImageManifest = serde_json::from_str(image::tests::TEST_MANIFEST).unwrap();
+        let manifest_bytes = serde_json::to_vec(&manifest).unwrap();
+        let manifest_entry = ImageIndexEntry {
+            media_type: manifest
+                .media_type
+                .as_ref()
+                .unwrap_or(&OCI_IMAGE_MEDIA_TYPE.to_string())
+                .to_string(),
+            size: manifest_bytes.len() as i64,
+            digest: OciStorage::blob_hash(&manifest_bytes),
+            platform: None,
+            annotations: Some(HashMap::from([(
+                REF_ANNOTATION.to_string(),
+                OciStorage::normalize_reference(
+                    &image::build_image_reference(image::tests::TEST_IMAGE_NAME)
+                        .unwrap()
+                        .whole(),
+                ),
+            )])),
+        };
+
+        let expected_index = OciImageIndex {
+            schema_version: 2,
+            media_type: None,
+            manifests: vec![manifest_entry],
+            annotations: None,
+        };
+        let expected_index = json!(expected_index);
+
+        assert_eq!(index, expected_index);
+    }
+
+    #[test]
+    fn test_fetch_manifest() {
+        let (root_dir, _storage) = setup_temp_storage();
+        let root_path = root_dir.as_path();
+
+        let manifest_digest = OciStorage::blob_hash(
+            &image::tests::TEST_MANIFEST
+                .to_string()
+                .replace("\n", "")
+                .replace(" ", "")
+                .as_bytes(),
+        );
+
+        let manifest = OciStorage::fetch_manifest(&root_path, &manifest_digest)
+            .expect("failed to fetch image manifest from storage");
+        let manifest = json!(manifest);
+
+        let val: serde_json::Value = serde_json::from_str(image::tests::TEST_MANIFEST).unwrap();
+
+        assert_eq!(manifest, val);
+    }
+
+    #[test]
+    fn test_fetch_config() {
+        let (root_dir, _storage) = setup_temp_storage();
+        let root_path = root_dir.as_path();
+
+        let config = OciStorage::fetch_config(&root_path, image::tests::TEST_IMAGE_HASH)
+            .expect("failed to fetch image config from storage");
+
+        let expected_config =
+            image::deserialize_from_reader(image::tests::TEST_CONFIG.as_bytes()).unwrap();
+
+        assert_eq!(config, expected_config);
     }
 }

--- a/enclave_build/src/storage.rs
+++ b/enclave_build/src/storage.rs
@@ -20,7 +20,7 @@ use sha2::Digest;
 use oci_spec::image::ImageConfiguration;
 
 use crate::{
-    image::{self, deserialize_from_reader},
+    image::{self, deserialize_from_reader, ImageDetails},
     EnclaveBuildError, Result,
 };
 
@@ -214,7 +214,7 @@ impl OciStorage {
     }
 
     /// Determines if an image is stored correctly
-    fn check_stored_image(&self, image_name: &str) -> Result<()> {
+    fn check_stored_image(&self, image_name: &str) -> Result<ImageConfiguration> {
         // Check that the index file exists
         let index: OciImageIndex = Self::fetch_index(&self.root_path)?;
 
@@ -248,7 +248,7 @@ impl OciStorage {
             ));
         }
 
-        Ok(())
+        deserialize_from_reader(config_string.as_bytes())
     }
 
     /// Validates that the image layers are stored correctly by checking them with the layer
@@ -403,10 +403,37 @@ impl OciStorage {
     fn blob_hash(bytes: &[u8]) -> String {
         format!("sha256:{:x}", sha2::Sha256::digest(bytes))
     }
+
+    /// Fetches the image metadata from storage as an ImageDetails struct.
+    ///
+    /// If the data is not correctly stored or a file is missing, it returns an error.
+    ///
+    /// If the image is not stored, it does not attempt to pull the image from remote.
+    pub fn fetch_image_details(&mut self, image_name: &str) -> Result<ImageDetails> {
+        let image_config = self
+            .config
+            .as_ref()
+            .map(Ok)
+            .unwrap_or_else(|| Err(self.check_stored_image(image_name)))
+            .map_err(|err| EnclaveBuildError::OciStorageMalformed(format!("{:?}", err)))?;
+
+        // Add algorithm prefix to the hash
+        let image_hash = Self::blob_hash(
+            &serde_json::to_vec(&self.config).map_err(EnclaveBuildError::SerdeError)?,
+        );
+
+        Ok(ImageDetails::new(
+            image::build_image_reference(image_name)?.whole(),
+            image_hash,
+            image_config.clone(),
+        ))
+    }
 }
 
 #[cfg(test)]
 pub mod tests {
+    use crate::image::build_image_reference;
+
     use super::*;
     use std::collections::HashMap;
 
@@ -567,5 +594,40 @@ pub mod tests {
         let expected_config = image::tests::TEST_CONFIG.to_string();
 
         assert_eq!(config, expected_config);
+    }
+
+    #[test]
+    fn test_fetch_image_details() {
+        let (_root_path, mut storage) = setup_temp_storage();
+
+        let image_details = storage
+            .fetch_image_details(image::tests::TEST_IMAGE_NAME)
+            .expect("failed to get image hash from storage");
+
+        let expected_config: ImageConfiguration =
+            deserialize_from_reader(image::tests::TEST_CONFIG.as_bytes()).unwrap();
+        let expected_hash = OciStorage::blob_hash(&expected_config.to_string().unwrap().as_bytes());
+        let expected_details = ImageDetails::new(
+            build_image_reference(image::tests::TEST_IMAGE_NAME)
+                .unwrap()
+                .whole(),
+            expected_hash,
+            expected_config,
+        );
+
+        assert_eq!(image_details, expected_details);
+    }
+
+    #[test]
+    fn test_fetch_image_details_empty_storage() {
+        // Initialize storage without storing any image (`storage` field should be `None`)
+        let root_dir = TempDir::new().unwrap();
+        fs::create_dir_all(&root_dir.as_path()).unwrap();
+        let mut storage =
+            OciStorage::new(&root_dir.as_path()).expect("failed to create the OciStorage");
+
+        assert!(storage
+            .fetch_image_details(image::tests::TEST_IMAGE_NAME)
+            .is_err());
     }
 }

--- a/enclave_build/src/storage.rs
+++ b/enclave_build/src/storage.rs
@@ -1,0 +1,62 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#![allow(dead_code)]
+use std::{
+    fs::{self},
+    path::{Path, PathBuf},
+};
+
+use oci_spec::image::ImageConfiguration;
+
+use crate::{EnclaveBuildError, Result};
+
+/// Root folder for the image storage.
+const STORAGE_ROOT_FOLDER: &str = "XDG_DATA_HOME";
+/// Path to the blobs folder
+const STORAGE_BLOBS_FOLDER: &str = "blobs/sha256/";
+/// Name of the storage index file which stores the (image URI <-> image hash) mappings.
+const STORAGE_INDEX_FILE_NAME: &str = "index.json";
+/// The name of the OCI layout file from the storage.
+const STORAGE_OCI_LAYOUT_FILE: &str = "oci-layout";
+
+/// Constants used for complying with the OCI storage structure
+const REF_ANNOTATION: &str = "org.opencontainers.image.ref.name";
+const OCI_LAYOUT: (&str, &str) = ("imageLayoutVersion", "1.0.0");
+
+/// Structure which provides operations with the local storage.
+///
+/// The index file is located in the storage root folder and keeps track of stored images.
+///
+/// The storage structure is:
+///
+/// {STORAGE_ROOT_PATH}/index.json\
+/// {STORAGE_ROOT_PATH}/blobs/sha256\
+/// {STORAGE_ROOT_PATH}/blobs/sha256/hash_of_blob_1\
+/// {STORAGE_ROOT_PATH}/blobs/sha256/hash_of_blob_2\
+/// etc.
+///
+/// A blob can be:
+///
+/// {IMAGE_FOLDER_PATH}/blobs/sha256/manifest_hash - the image manifest, stored as a JSON String.\
+/// {IMAGE_FOLDER_PATH}/blobs/sha256/config_hash - the image configuration, stored as a JSON String.\
+/// {IMAGE_FOLDER_PATH}/blobs/sha256/layer_hash - one of the image layers, each in a separate gzip compressed tar file.
+pub struct OciStorage {
+    /// The root folder of the storage
+    root_path: PathBuf,
+
+    /// The config of the OCI image used to build the EIF. This field is optional as we might
+    /// not have stored an image and we have to pull it from a remote registry.
+    config: Option<ImageConfiguration>,
+}
+
+impl OciStorage {
+    pub fn new(root_path: &Path) -> Result<Self> {
+        // Create all missing folders, if not already created
+        fs::create_dir_all(root_path).map_err(EnclaveBuildError::OciStorageInit)?;
+
+        Ok(Self {
+            root_path: root_path.to_path_buf(),
+            config: None,
+        })
+    }
+}


### PR DESCRIPTION
OCI storage

Implemented an OCI compliant storage for pull and inspect operations. This storage can be directly used by `linuxkit` as its own cache, preventing it to pull the images again. The structure of the storage directory is as follows:

```
storage_dir/
|________index.json        -> points to the manifest blob for each image
|________oci-layout
|            blobs/sha256/
|            |_______manifest_hash  -> points to config and layers
|            |_______config_hash
|            |_______layer_hash
```
The storage module supports store and fetching operations. The first fetch validates the files for the requested image and loads the config in the memory (the following fetches will use this config). Only one config is stored as we do not need to keep track of all the stored images when building an EIF.

When later adding the OCI archive feature, extracted image contents can be directly added to the storage and used by `nitro-cli` and `linuxkit` as well.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
