### PR TITLE
nitro-enclaves-allocator: Set local language to English

### DIFF
--- a/bootstrap/nitro-enclaves-allocator
+++ b/bootstrap/nitro-enclaves-allocator
@@ -5,6 +5,11 @@
 # Its purpose is to reserve the requested memory and CPUs (specified in
 # /etc/nitro_enclaves/allocator.yaml).
 
+# Set language to English. This way the parsing logic from the current script
+# works properly when a different language is set in the locale configuration
+# (e.g. /etc/locale.conf).
+LANG=en_US.UTF-8
+
 # The file which holds the CPU pool.
 CPU_POOL_FILE="/sys/module/nitro_enclaves/parameters/ne_cpus"
 


### PR DESCRIPTION
The parsing logic from the nitro-enclaves-allocator script doesn't work properly when a different language than English is set in the locale configuration (e.g. /etc/locale.conf).

Set the language to English in the nitro-enclaves-allocator script to fix this possible issue.

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

*Issue #428*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
