### PR TITLE
clippy: fix minor issue

### DIFF
--- a/enclave_build/src/docker.rs
+++ b/enclave_build/src/docker.rs
@@ -98,7 +98,7 @@ impl DockerUtil {
                         .to_string();
 
                     let auth = auth.replace('"', "");
-                    let decoded = base64::decode(&auth).map_err(|err| {
+                    let decoded = base64::decode(auth).map_err(|err| {
                         CredentialsError(format!("Invalid Base64 encoding for auth: {}", err))
                     })?;
                     let decoded = std::str::from_utf8(&decoded).map_err(|err| {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -297,7 +297,7 @@ fn vsock_set_connect_timeout(fd: RawFd, millis: i64) -> NitroCliResult<()> {
     let timeval = TimeVal::milliseconds(millis);
     let ret = unsafe {
         libc::setsockopt(
-            fd as i32,
+            fd,
             libc::AF_VSOCK,
             SO_VM_SOCKETS_CONNECT_TIMEOUT,
             &timeval as *const _ as *const c_void,


### PR DESCRIPTION
error: the borrowed expression implements the required traits
   --> enclave_build/src/docker.rs:101:50
    |
101 |                     let decoded = base64::decode(&auth).map_err(|err| {
    |                                                  ^^^^^ help: change this to: `auth`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>
