### PR TITLE
CI: use get-login-password instead of get-login

### DIFF
--- a/ci_entrypoint.sh
+++ b/ci_entrypoint.sh
@@ -51,7 +51,7 @@ set +e
 TEST_RESULTS=$?
 set -e
 
-aws s3 cp test_logs.out s3://aws-nitro-enclaves-cli/${LOGS_PATH}
+aws s3 cp --content-type 'text/plain' test_logs.out s3://aws-nitro-enclaves-cli/${LOGS_PATH}
 
 STATE="success"
 if [[ "${TEST_RESULTS}" != "0" ]];then

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -121,6 +121,7 @@ do
 
 	configure_ne_driver
 
+	timeout 5m \
 	./build/nitro_cli/"${ARCH}"-unknown-linux-musl/release/deps/"${test_exec_name}" \
 		--test-threads=1 --nocapture || test_failed
 done < <(grep -v '^ *#' < build/test_executables.txt)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,7 +14,11 @@ export NITRO_CLI_BLOBS="${SCRIPTDIR}/blobs"
 export NITRO_CLI_ARTIFACTS="${SCRIPTDIR}/build"
 ARCH="$(uname -m)"
 
-$(aws ecr get-login --no-include-email --region us-east-1)
+AWS_ACCOUNT_ID=667861386598
+ECR_REGION=us-east-1
+ECR_URL="$AWS_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com"
+
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_URL
 
 # Indicate that the test suite has failed
 function register_test_fail() {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -58,7 +58,7 @@ function configure_ne_driver() {
 		# Preallocate 2046 Mb, that should be enough for all the tests. We explicitly
 		# pick this value to have both 1 GB and 2 MB pages if the system allows it.
 		source build/install/etc/profile.d/nitro-cli-env.sh || test_failed
-		./build/install/etc/profile.d/nitro-cli-config -m 2046 -p 1,3 || test_failed
+		./build/install/etc/profile.d/nitro-cli-config -m 2046 -t 2 || test_failed
 	fi
 }
 


### PR DESCRIPTION
It's not recommended to use get-login anymore, since the temporary password is printed out.

Signed-off-by: Petre Eftime <epetre@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
