### PR TITLE
Image Manager trait for Docker

### DIFF
--- a/enclave_build/src/lib.rs
+++ b/enclave_build/src/lib.rs
@@ -16,7 +16,6 @@ mod yaml_generator;
 use aws_nitro_enclaves_image_format::defs::{EifBuildInfo, EifIdentityInfo, EIF_HDR_ARCH_ARM64};
 use aws_nitro_enclaves_image_format::utils::identity::parse_custom_metadata;
 use aws_nitro_enclaves_image_format::utils::{EifBuilder, SignEnclaveInfo};
-use docker::DockerUtil;
 use serde_json::json;
 use sha2::Digest;
 use std::collections::BTreeMap;
@@ -27,7 +26,7 @@ pub const DEFAULT_TAG: &str = "1.0";
 
 #[derive(Debug, Error)]
 pub enum EnclaveBuildError {
-    #[error("Docker error: `{0}`")]
+    #[error("Docker error: `{0:?}`")]
     DockerError(String),
     #[error("Invalid path: `{0}`")]
     PathError(String),
@@ -85,9 +84,16 @@ pub enum EnclaveBuildError {
 
 pub type Result<T> = std::result::Result<T, EnclaveBuildError>;
 
+#[allow(dead_code)]
+enum ImageType {
+    Docker,
+    Oci,
+}
+
 pub struct Docker2Eif<'a> {
-    docker_image: String,
-    docker: DockerUtil,
+    /// This field can be any struct that implements the 'ImageManager' trait.
+    image_manager: Box<dyn image_manager::ImageManager>,
+    image_type: ImageType,
     init_path: String,
     nsm_path: String,
     kernel_img_path: String,
@@ -103,8 +109,11 @@ pub struct Docker2Eif<'a> {
 }
 
 impl<'a> Docker2Eif<'a> {
+    /// Decide on the type of image and build method of the EIF from based on build arguments.
+    /// The presence of `--docker-uri` alone or along `--docker-dir` prompts the usage of the Docker daemon.
     pub fn new(
-        docker_image: String,
+        docker_image: Option<String>,
+        docker_dir: Option<String>,
         init_path: String,
         nsm_path: String,
         kernel_img_path: String,
@@ -119,8 +128,34 @@ impl<'a> Docker2Eif<'a> {
         metadata_path: Option<String>,
         build_info: EifBuildInfo,
     ) -> Result<Self> {
-        let docker = DockerUtil::new(docker_image.clone());
         let blob_paths = Vec::from([&init_path, &nsm_path, &kernel_img_path, &linuxkit_path]);
+        let image_type;
+
+        // The flags usage was already validated by the commands parser, so now just check if the docker daemon
+        // should be used or not
+        let image_manager: Box<dyn image_manager::ImageManager> = match (&docker_image, &docker_dir)
+        {
+            // Docker directory present so try to build from Dockerfile
+            (Some(docker_image), Some(docker_dir)) => {
+                image_type = ImageType::Docker;
+                Box::new(crate::docker::DockerImageManager::from_dockerfile(
+                    docker_image,
+                    docker_dir,
+                )?)
+            }
+            // If the --docker-uri flag is used then the docker client is required either for pulling the image or
+            // for building it locally from the supplied Dockerfile in case --docker-dir is used too
+            (Some(docker_image), _) => {
+                image_type = ImageType::Docker;
+                Box::new(crate::docker::DockerImageManager::new(docker_image)?)
+            }
+            // TODO: add cases for --oci-image and --oci-archive when arguments are introduced
+            (_, _) => {
+                return Err(EnclaveBuildError::ImageDetailError(
+                    "Image directory or URI missing".to_string(),
+                ))
+            }
+        };
 
         blob_paths.iter().try_for_each(|path| {
             if !Path::new(path).is_file() {
@@ -152,8 +187,8 @@ impl<'a> Docker2Eif<'a> {
         };
 
         Ok(Docker2Eif {
-            docker_image,
-            docker,
+            image_manager,
+            image_type,
             init_path,
             nsm_path,
             kernel_img_path,
@@ -169,25 +204,10 @@ impl<'a> Docker2Eif<'a> {
         })
     }
 
-    pub fn pull_docker_image(&self) -> Result<()> {
-        self.docker.pull_image()?;
+    fn generate_identity_info(&mut self) -> Result<EifIdentityInfo> {
+        let docker_info = self.image_manager.inspect_image()?;
 
-        Ok(())
-    }
-
-    pub fn build_docker_image(&self, dockerfile_dir: String) -> Result<()> {
-        if !Path::new(&dockerfile_dir).is_dir() {
-            return Err(EnclaveBuildError::PathError(dockerfile_dir));
-        }
-        self.docker.build_image(dockerfile_dir)?;
-
-        Ok(())
-    }
-
-    fn generate_identity_info(&self) -> Result<EifIdentityInfo> {
-        let docker_info = self.docker.inspect_image()?;
-
-        let uri_split: Vec<&str> = self.docker_image.split(':').collect();
+        let uri_split: Vec<&str> = self.image_manager.image_name().split(':').collect();
         if uri_split.is_empty() {
             return Err(EnclaveBuildError::ImageDetailError(
                 "Wrong image name specified".to_string(),
@@ -231,11 +251,26 @@ impl<'a> Docker2Eif<'a> {
         })
     }
 
+    fn create_ramfs(&self, args: Vec<&str>) -> Result<()> {
+        let output = Command::new(&self.linuxkit_path)
+            .args(args)
+            .output()
+            .map_err(|e| EnclaveBuildError::LinuxKitError(format!("{:?}", e)))?;
+        if !output.status.success() {
+            return Err(EnclaveBuildError::LinuxKitError(format!(
+                "Linuxkit reported an error while creating ramfs: {:?}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        Ok(())
+    }
+
     pub fn create(&mut self) -> Result<BTreeMap<String, String>> {
-        let (cmd_file, env_file) = self.docker.load()?;
+        let (cmd_file, env_file) = self.image_manager.extract_expressions()?;
 
         let yaml_generator = YamlGenerator::new(
-            self.docker_image.clone(),
+            self.image_manager.image_name().to_string(),
             self.init_path.clone(),
             self.nsm_path.clone(),
             cmd_file.path().to_str().unwrap().to_string(),
@@ -254,55 +289,60 @@ impl<'a> Docker2Eif<'a> {
         let bootstrap_ramfs = format!("{}/bootstrap-initrd.img", self.artifacts_prefix);
         let customer_ramfs = format!("{}/customer-initrd.img", self.artifacts_prefix);
 
-        let output = Command::new(&self.linuxkit_path)
-            .args([
+        // Create the bootstrap ramfs
+        self.create_ramfs(
+            [
                 "build",
                 "-name",
                 &bootstrap_ramfs,
                 "-format",
                 "kernel+initrd",
                 ramfs_config_file.path().to_str().unwrap(),
-            ])
-            .output()
-            .map_err(|e| EnclaveBuildError::LinuxKitError(format!("{:?}", e)))?;
-        if !output.status.success() {
-            eprintln!(
-                "Linuxkit reported an error while creating the bootstrap ramfs: {:?}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-            return Err(EnclaveBuildError::LinuxKitError(format!(
-                "{:?}",
-                String::from_utf8_lossy(&output.stderr)
-            )));
+            ]
+            .to_vec(),
+        )?;
+
+        // If the docker daemon should be used, then call linuxkit with the '-docker' flag, which
+        // makes linuxkit search the image in the docker cache first.
+        // Otherwise, do not add the flag and let it pull the images itself, without docker.
+        match self.image_type {
+            ImageType::Docker => {
+                // Prefix the docker image filesystem, as expected by init
+                self.create_ramfs(
+                    [
+                        "build",
+                        // Use the docker daemon to first check if the image is in the docker cache
+                        "-docker",
+                        "-name",
+                        &customer_ramfs,
+                        "-format",
+                        "kernel+initrd",
+                        "-prefix",
+                        "rootfs/",
+                        ramfs_with_rootfs_config_file.path().to_str().unwrap(),
+                    ]
+                    .to_vec(),
+                )?;
+            }
+            ImageType::OCI => {
+                // In this case, linuxkit pulls the image itself
+                self.create_ramfs(
+                    [
+                        "build",
+                        "-name",
+                        &customer_ramfs,
+                        "-format",
+                        "kernel+initrd",
+                        "-prefix",
+                        "rootfs/",
+                        ramfs_with_rootfs_config_file.path().to_str().unwrap(),
+                    ]
+                    .to_vec(),
+                )?;
+            }
         }
 
-        // Prefix the docker image filesystem, as expected by init
-        let output = Command::new(&self.linuxkit_path)
-            .args([
-                "build",
-                "-docker",
-                "-name",
-                &customer_ramfs,
-                "-format",
-                "kernel+initrd",
-                "-prefix",
-                "rootfs/",
-                ramfs_with_rootfs_config_file.path().to_str().unwrap(),
-            ])
-            .output()
-            .map_err(|e| EnclaveBuildError::LinuxKitError(format!("{:?}", e)))?;
-        if !output.status.success() {
-            eprintln!(
-                "Linuxkit reported an error while creating the customer ramfs: {:?}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-            return Err(EnclaveBuildError::LinuxKitError(format!(
-                "{:?}",
-                String::from_utf8_lossy(&output.stderr)
-            )));
-        }
-
-        let arch = self.docker.architecture()?;
+        let arch = self.image_manager.architecture()?;
 
         let flags = match arch.as_str() {
             docker::DOCKER_ARCH_ARM64 => EIF_HDR_ARCH_ARM64,
@@ -312,13 +352,15 @@ impl<'a> Docker2Eif<'a> {
             }
         };
 
+        let eif_info = self.generate_identity_info()?;
+
         let mut build = EifBuilder::new(
             Path::new(&self.kernel_img_path),
             self.cmdline.clone(),
             self.sign_info.clone(),
             sha2::Sha384::new(),
             flags,
-            self.generate_identity_info()?,
+            eif_info,
         );
 
         // Linuxkit adds -initrd.img sufix to the file names.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,8 @@ pub fn build_from_docker(
     })?;
 
     let mut docker2eif = enclave_build::Docker2Eif::new(
-        docker_uri.to_string(),
+        Some(docker_uri.to_string()),
+        docker_dir.clone(),
         format!("{}/init", blobs_path),
         format!("{}/nsm.ko", blobs_path),
         kernel_path,
@@ -148,23 +149,6 @@ pub fn build_from_docker(
         )
     })?;
 
-    if let Some(docker_dir) = docker_dir {
-        docker2eif
-            .build_docker_image(docker_dir.clone())
-            .map_err(|err| {
-                new_nitro_cli_failure!(
-                    &format!("Failed to build docker image: {:?}", err),
-                    NitroCliErrorEnum::DockerImageBuildError
-                )
-            })?;
-    } else {
-        docker2eif.pull_docker_image().map_err(|err| {
-            new_nitro_cli_failure!(
-                &format!("Failed to pull docker image: {:?}", err),
-                NitroCliErrorEnum::DockerImagePullError
-            )
-        })?;
-    }
     let measurements = docker2eif.create().map_err(|err| {
         new_nitro_cli_failure!(
             &format!("Failed to create EIF image: {:?}", err),


### PR DESCRIPTION
The build EIF process should have the same workflow for both OCI and Docker. In the previous PR #438 I introduced and implemented the Image Manager trait for OCI while changing the workflow to pull/build the required container image on manager instantiation. This way subsequent pulls are no longer needed for inspect operations.

The Docker workflow was using the docker daemon to access the local image storage (still using the pull API in Rust) thus having a different interface that the trait offers. With this refactoring we can manipulate both types of images with the same operations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
