### PR TITLE
Fix clippy error useless_vec

### DIFF
--- a/src/enclave_proc_comm.rs
+++ b/src/enclave_proc_comm.rs
@@ -190,7 +190,7 @@ where
 
     // Get the number of expected replies.
     let mut num_replies_expected = comms.len() - num_errors;
-    let mut events = vec![EpollEvent::empty(); 1];
+    let mut events = [EpollEvent::empty(); 1];
 
     while num_replies_expected > 0 {
         let num_events = loop {


### PR DESCRIPTION
Removed useless `vec!` macro

* Issue
```
14:40 $ cargo clippy --all
    Checking eif_loader v0.1.0 (/tmp/aws-nitro-enclaves-cli/eif_loader)
    Checking enclave_build v0.1.0 (/tmp/aws-nitro-enclaves-cli/enclave_build)
    Checking driver-bindings v0.1.0 (/tmp/aws-nitro-enclaves-cli/driver-bindings)
    Checking vsock-proxy v0.1.0 (/tmp/aws-nitro-enclaves-cli/vsock_proxy)
    Checking nitro-cli v1.2.2 (/tmp/aws-nitro-enclaves-cli)
error: useless use of `vec!`
   --> src/enclave_proc_comm.rs:193:22
    |
193 |     let mut events = vec![EpollEvent::empty(); 1];
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use an array directly: `[EpollEvent::empty(); 1]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
note: the lint level is defined here
   --> src/enclave_proc_comm.rs:4:9
    |
4   | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(clippy::useless_vec)]` implied by `#[deny(warnings)]`

error: could not compile `nitro-cli` (lib) due to previous error
```

*Description of changes:*

The only commit of the PR contains a little code amendment with respect to [useless_vec](https://rust-lang.github.io/rust-clippy/master/index.html#/useless_vec)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
