### PR TITLE
SPECS/aws-nitro-enclaves-cli.spec: Do not mangle shebangs

### DIFF
--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -15,6 +15,9 @@
 %define _third_party_licenses_file %{_datadir}/licenses/%{name}-%{version}/%{_licenses_filename}
 %define _pkg_licenses_file %{_src_dir}/%{_licenses_filename}
 
+# Stop mangling shebangs for scripts from examples
+%global __brp_mangle_shebangs_exclude_from %{ne_data_dir}/examples/
+
 Summary:    AWS Nitro Enclaves tools for managing enclaves
 Name:       aws-nitro-enclaves-cli
 Version:    1.2.2


### PR DESCRIPTION
The package builder used for Amazon Linux 2023 mangles shebangs in the packaged scripts, but the new paths may not exist. For example, in the case of `hello.sh`, the shebang is rewritten from `#!/bin/sh` to `#!/usr/bin/sh`, but the latter path does not exist. This has the effect of preventing the "Hello Enclave" enclave from being instantiated. Therefore we disable shebang mangling for the entire package.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
