### PR TITLE
run_tests.sh: Load vsock_loopback module for vsock-proxy tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -109,6 +109,11 @@ sed -i 's/CMD/ENTRYPOINT/g' examples/"${ARCH}"/hello-entrypoint/Dockerfile || te
 nitro-cli build-enclave --docker-dir examples/"${ARCH}"/hello-entrypoint --docker-uri hello-entrypoint-usage \
 	--output-file test_images/hello-entrypoint-usage.eif || test_failed
 
+# Load vsock_loopback module for connection_test test of vsock-proxy
+if [ "$(lsmod | grep -cw vsock_loopback)" -eq 0 ]; then
+	modprobe vsock_loopback || echo "Module vsock_loopback not available."
+fi
+
 # Run all unit tests
 while IFS= read -r test_line
 do


### PR DESCRIPTION
The `connection_test` test runs the vsock-proxy on the parent instance for testing the connection between a server and a client on the same instance, in which case the vsock loopback must be enabled on the parent instance.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
