### PR TITLE
command-executer: Replace deprecated SockAddr with VsockAddr

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -123,7 +123,7 @@ do
 
 	configure_ne_driver
 
-	timeout 5m \
+	timeout 7m \
 	./build/nitro_cli/"${ARCH}"-unknown-linux-musl/release/deps/"${test_exec_name}" \
 		--test-threads=1 --nocapture || test_failed
 done < <(grep -v '^ *#' < build/test_executables.txt)

--- a/samples/command_executer/Cargo.toml
+++ b/samples/command_executer/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.60"
 [dependencies]
 clap = "3.2"
 log = "0.4"
-nix = "0.23"
+nix = "0.26"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = "1.0"
 byteorder = "1.3"

--- a/samples/command_executer/src/lib.rs
+++ b/samples/command_executer/src/lib.rs
@@ -7,7 +7,7 @@ use protocol_helpers::{recv_loop, recv_u64, send_loop, send_u64};
 
 use nix::sys::socket::listen as listen_vsock;
 use nix::sys::socket::{accept, bind, connect, shutdown, socket};
-use nix::sys::socket::{AddressFamily, Shutdown, SockAddr, SockFlag, SockType};
+use nix::sys::socket::{AddressFamily, Shutdown, VsockAddr, SockFlag, SockType};
 use nix::unistd::close;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -56,7 +56,7 @@ impl AsRawFd for VsockSocket {
 }
 
 fn vsock_connect(cid: u32, port: u32) -> Result<VsockSocket, String> {
-    let sockaddr = SockAddr::new_vsock(cid, port);
+    let sockaddr = VsockAddr::new(cid, port);
     let mut err_msg = String::new();
 
     for i in 0..MAX_CONNECTION_ATTEMPTS {
@@ -197,7 +197,7 @@ pub fn listen(args: ListenArgs) -> Result<(), String> {
     )
     .map_err(|err| format!("Create socket failed: {:?}", err))?;
 
-    let sockaddr = SockAddr::new_vsock(VMADDR_CID_ANY, args.port);
+    let sockaddr = VsockAddr::new(VMADDR_CID_ANY, args.port);
 
     bind(socket_fd, &sockaddr).map_err(|err| format!("Bind failed: {:?}", err))?;
 


### PR DESCRIPTION
Currently the `run_describe_terminate_command_executer_docker_image` test fails when using the deprecated SockAddr dependency because the console output of the enclave under test is not entirely captured. Fortunately, switching to VsockAddr fixes that.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
