### PR TITLE
command-executer: Fix order to Rust imports

### DIFF
--- a/samples/command_executer/src/lib.rs
+++ b/samples/command_executer/src/lib.rs
@@ -7,7 +7,7 @@ use protocol_helpers::{recv_loop, recv_u64, send_loop, send_u64};
 
 use nix::sys::socket::listen as listen_vsock;
 use nix::sys::socket::{accept, bind, connect, shutdown, socket};
-use nix::sys::socket::{AddressFamily, Shutdown, VsockAddr, SockFlag, SockType};
+use nix::sys::socket::{AddressFamily, Shutdown, SockFlag, SockType, VsockAddr};
 use nix::unistd::close;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;


### PR DESCRIPTION
Previous changes overlooked the fact that imports have to be sorted alphabetically.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
