### PR TITLE
nitro_enclaves: Fix race when accessing has_event flag

### DIFF
--- a/drivers/virt/nitro_enclaves/ne_misc_dev.c
+++ b/drivers/virt/nitro_enclaves/ne_misc_dev.c
@@ -1645,8 +1645,12 @@ static __poll_t ne_enclave_poll(struct file *file, poll_table *wait)
 
 	poll_wait(file, &ne_enclave->eventq, wait);
 
+	mutex_lock(&ne_enclave->enclave_info_mutex);
+
 	if (ne_enclave->has_event)
 		mask |= EPOLLHUP;
+
+	mutex_unlock(&ne_enclave->enclave_info_mutex);
 
 	return mask;
 }


### PR DESCRIPTION
The `has_event` flag is set while holding the `enclave_info_mutex` mutex. Let's also hold the mutex while reading the flag to avoid races.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
