### PR TITLE
vsock_proxy: set log level to warn

### DIFF
--- a/vsock_proxy/README.md
+++ b/vsock_proxy/README.md
@@ -100,3 +100,10 @@ systemctl enable nitro-enclaves-vsock-proxy.service
 The service files can be found in `service` directory. The proxy is ran using the default configuration
 from `/etc/nitro_enclaves/vsock-proxy.yaml`, on local port 8000 and the AWS KMS endpoint corresponding to
 the region of the instance.
+
+You can use the following command to check the vsock proxy logs to diagnose connectivity issues.
+```
+journalctl -eu nitro-enclaves-vsock-proxy.service
+```
+To enable more detailed logging output, set the `RUST_LOG` environment variable to the `trace` log level in
+the service file (e.g.`/usr/lib/systemd/system/nitro-enclaves-vsock-proxy.service`).

--- a/vsock_proxy/service/nitro-enclaves-vsock-proxy.service
+++ b/vsock_proxy/service/nitro-enclaves-vsock-proxy.service
@@ -8,11 +8,11 @@ Type=simple
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=vsock-proxy
+# Use RUST_LOG=trace for more verbose logging
 ExecStart=/bin/bash -ce "TOKEN=$(curl --silent -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\") ; \
 			REGION=$(curl --silent -H \"X-aws-ec2-metadata-token: $TOKEN\" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region) ; \
 			[ -z \"$REGION\" ] && REGION=$(curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region) ; \
-			exec /usr/bin/vsock-proxy 8000 kms.$${REGION}.amazonaws.com 443 \
-                --config /etc/nitro_enclaves/vsock-proxy.yaml"
+			RUST_LOG=warn exec /usr/bin/vsock-proxy 8000 kms.$${REGION}.amazonaws.com 443 --config /etc/nitro_enclaves/vsock-proxy.yaml"
 Restart=always
 TimeoutSec=0
 


### PR DESCRIPTION
Initially, logging was disabled by default for the vsock service. This change enables warning and error logs, allowing easier troubleshooting of connectivity issues.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
