### PR TITLE
cargo: Upgrade num-derive to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
  "clap",
  "crc",
  "hex",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "openssl",
  "serde",
@@ -260,7 +260,7 @@ dependencies = [
  "log",
  "nix 0.26.2",
  "num",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "serde",
  "serde_json",
@@ -1052,7 +1052,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.26.2",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "openssl",
  "page_size",
@@ -1156,6 +1156,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ bindgen = { version=">=0.54" }
 
 [dev-dependencies]
 log = "0.4"
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"
 tempfile = "3.5"
 

--- a/samples/command_executer/Cargo.toml
+++ b/samples/command_executer/Cargo.toml
@@ -15,5 +15,5 @@ serde = { version = ">=1.0", features = ["derive"] }
 serde_json = "1.0"
 byteorder = "1.3"
 num = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"


### PR DESCRIPTION
The num-derive crate version 0.3 is no longer compatible with the current nightly Rust toolchain. Upgrading to version 0.4 to ensure compatibility and allow successful builds.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
