### PR TITLE
command_executer - recv infinite loop

### DIFF
--- a/samples/command_executer/src/protocol_helpers.rs
+++ b/samples/command_executer/src/protocol_helpers.rs
@@ -54,6 +54,7 @@ pub fn recv_loop(fd: RawFd, buf: &mut [u8], len: u64) -> Result<(), String> {
 
     while recv_bytes < len {
         let size = match recv(fd, &mut buf[recv_bytes..len], MsgFlags::empty()) {
+            Ok(0) => return Err(format!("{:?}", "Peer closed connection")),
             Ok(size) => size,
             Err(nix::errno::Errno::EINTR) => 0,
             Err(err) => return Err(format!("{:?}", err)),


### PR DESCRIPTION
The command_executer/src/protocol_helpers.rs has a denial of service bug. The `recv` method may return 0 bytes (the `size`) variable, and this case is not accounted for: the 0 may be added to the `recv_bytes` infinitely.

Similar issue exists in vsock_sample: https://github.com/aws/aws-nitro-enclaves-samples/blob/dc4bba3d99bc4988a87ce7775cf1bc554537da16/vsock_sample/rs/src/protocol_helpers.rs#L45-L52

Correct handling is implemented in python versions and in the kmstool: https://github.com/aws/aws-nitro-enclaves-sdk-c/blob/550f7313bf792bf03200c7c6e1ac3fd7d2dc382f/bin/kmstool-enclave/main.c#L245-L247

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
