### PR TITLE
clippy: resolve build errors for Rust 1.78

### DIFF
--- a/src/enclave_proc/resource_manager.rs
+++ b/src/enclave_proc/resource_manager.rs
@@ -169,14 +169,13 @@ pub struct EnclaveManager {
     enclave_handle: Arc<Mutex<EnclaveHandle>>,
 }
 
-impl ToString for EnclaveState {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for EnclaveState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EnclaveState::Empty => "EMPTY",
-            EnclaveState::Running => "RUNNING",
-            EnclaveState::Terminating => "TERMINATING",
+            EnclaveState::Empty => write!(f, "EMPTY"),
+            EnclaveState::Running => write!(f, "RUNNING"),
+            EnclaveState::Terminating => write!(f, "TERMINATING"),
         }
-        .to_string()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub fn describe_eif(eif_path: String) -> NitroCliResult<EifDescribeInfo> {
     };
 
     // Check if signature section is present
-    if measurements.get(&"PCR8".to_string()).is_some() {
+    if measurements.contains_key("PCR8") {
         let cert_info = eif_reader
             .get_certificate_info(measurements)
             .map_err(|err| {


### PR DESCRIPTION
Resolving a couple of clippy errors when building with Rust 1.78:
* https://rust-lang.github.io/rust-clippy/master/index.html\#/unnecessary_get_then_check
* https://rust-lang.github.io/rust-clippy/master/index.html\#/unnecessary_to_owned
* https://rust-lang.github.io/rust-clippy/master/index.html\#/to_string_trait_impl

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
