### PR TITLE
vsock_proxy: Use system-configured nameservers for DNS resolution

### DIFF
--- a/vsock_proxy/src/dns.rs
+++ b/vsock_proxy/src/dns.rs
@@ -6,7 +6,6 @@
 use std::net::IpAddr;
 
 use chrono::{DateTime, Duration, Utc};
-use hickory_resolver::config::*;
 use hickory_resolver::Resolver;
 use idna::domain_to_ascii;
 
@@ -51,11 +50,12 @@ pub fn resolve(addr: &str, ip_addr_type: IpAddrType) -> VsockProxyResult<Vec<Dns
     // IDNA parsing
     let addr = domain_to_ascii(addr).map_err(|_| "Could not parse domain name")?;
 
+    // Initialize a DNS resolver using the system's configured nameservers.
+    let resolver = Resolver::from_system_conf()
+        .map_err(|_| "Error while initializing DNS resolver!".to_string())?;
+
     // DNS lookup
     // It results in a vector of IPs (V4 and V6)
-    let resolver = Resolver::new(ResolverConfig::default(), ResolverOpts::default())
-        .map_err(|_| "Error while initializing DNS resolver!")?;
-
     let rresults: Vec<DnsResolutionInfo> = resolver
         .lookup_ip(addr)
         .map_err(|_| "DNS lookup failed!")?


### PR DESCRIPTION
*Description of changes:*

This commit changes the DNS resolver's initialization to use the system's configured nameservers instead of the default nameserver provided by hickoery-resolver crate.

The `Resolver::from_system_conf()` method is now used to initialize the DNS resolver. This method attempts to read the system's nameserver configuration, which may come from various sources such as `/etc/resolv.conf`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
