### PR TITLE
Prepare for Release v1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "vsock-proxy"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "nitro-cli"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "aws-nitro-enclaves-image-format",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitro-cli"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -20,7 +20,7 @@
 
 Summary:    AWS Nitro Enclaves tools for managing enclaves
 Name:       aws-nitro-enclaves-cli
-Version:    1.3.0
+Version:    1.3.1
 Release:    0%{?dist}
 
 License:    Apache 2.0
@@ -195,6 +195,12 @@ fi
 %{ne_include_dir}/*
 
 %changelog
+* Mon Jun 3 2024 Erdem Meydanli <meydanli@amazon.com> - 1.3.1-0
+- vsock-proxy: Bump version to 1.0.1
+- vsock_proxy: Use system-configured nameservers for DNS resolution
+- Update init blob to support user namespaces
+- clippy: resolve build errors for Rust 1.78
+
 * Tue Apr 16 2024 Erdem Meydanli <meydanli@amazon.com> - 1.3.0-0
 + This release focuses on resolving two critical issues:
 the vsock-proxy DNS lookup limitation (#553) and the compatibility

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -639,7 +639,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.3.0</a></li>
+                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.3.1</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-53eac21b7bfd5c336846d04c2288c2a62cddd992  nitro-cli-dependencies.tar.gz
+27e70be63e4c1f05eb80dbea6985753f2da61083  nitro-cli-dependencies.tar.gz

--- a/vsock_proxy/Cargo.toml
+++ b/vsock_proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vsock-proxy"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 rust-version = "1.68"

--- a/vsock_proxy/src/main.rs
+++ b/vsock_proxy/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #![deny(warnings)]
 
@@ -6,7 +6,7 @@
 /// Example of usage:
 /// vsock-proxy 8000 127.0.0.1 9000
 ///
-use clap::{App, AppSettings, Arg};
+use clap::{App, Arg};
 use env_logger::init;
 use log::info;
 
@@ -20,7 +20,7 @@ fn main() -> VsockProxyResult<()> {
 
     let matches = App::new("Vsock-TCP proxy")
         .about("Vsock-TCP proxy")
-        .setting(AppSettings::DisableVersion)
+        .version(env!("CARGO_PKG_VERSION"))
         .arg(
             Arg::with_name("ipv4")
                 .short('4')


### PR DESCRIPTION
*Description of changes:*

- vsock-proxy: Bump version to 1.0.1
- vsock_proxy: Use system-configured nameservers for DNS resolution
- Update init blob to support user namespaces
- clippy: resolve build errors for Rust 1.78

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
