### PR TITLE
scripts/run_tests.sh: Add check dependencies

### DIFF
--- a/scripts/lib_tests.sh
+++ b/scripts/lib_tests.sh
@@ -13,6 +13,33 @@ export NITRO_CLI_ARTIFACTS="$SCRIPTDIR/../build"
 ARCH="$(uname -m)"
 AWS_ACCOUNT_ID=667861386598
 
+check_dependencies() {
+	# check we are root
+	if [ "${EUID}" -ne 0 ]
+	then
+		echo "The testing requires the capabilities to load and unload kernel modules. Please run as root."
+		exit 1
+	fi
+
+	# Check that docker is available
+	if ! type docker; then
+		echo "Could not find docker installed. Please ensure you have docker installed and reachable through your PATH."
+		exit 1
+	fi
+
+	# ...and usable
+	if ! docker ps; then
+		echo "Docker seems to be not functional. Please ensure docker can be used by $USER."
+		exit 1
+	fi
+
+	# The testing relies on pytest-3 for orchestration. Ensure we have that installed.
+	if ! type pytest-3; then
+		echo "Could not find pytest-3 installed. Please ensure you have pytest-3 installed and reachable through your PATH."
+		exit 1
+	fi
+}
+
 test_start() {
 	TEST_SUITES_TOTAL=$((TEST_SUITES_TOTAL + 1))
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -13,6 +13,8 @@ source "$SCRIPTDIR/lib_tests.sh"
 
 trap test_failed ERR
 
+check_dependencies
+
 # Build and install NE CLI
 build_and_install
 


### PR DESCRIPTION
**Issue #, if available:** -

**Description of changes:**

```
scripts/run_tests.sh: Add check dependencies

Check that all the dependencies to run the test script are in place and bail out early before spending time on needless work.

The dependencies are:
* running as root
* docker has to function
* pytest-3 needs to be installed
```

When testing builds for https://github.com/aws/aws-nitro-enclaves-sdk-bootstrap/pull/28 I struggled through some hardships with the dependencies needed to run the test scripts. Let's make this easier for the next person by bailing out early if dependencies are not met.

**Testing done:**

Tested all cases starting from a vanilla Ubuntu instance running without root privileges, adding another dependency with each iteration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
