### PR TITLE
clippy: resolve build errors for Rust 1.79

### DIFF
--- a/samples/command_executer/src/lib.rs
+++ b/samples/command_executer/src/lib.rs
@@ -283,12 +283,7 @@ pub fn run(args: RunArgs) -> Result<i32, String> {
     print!("{}", output.stdout);
     eprint!("{}", output.stderr);
 
-    let rc = match output.rc {
-        Some(code) => code,
-        _ => 0,
-    };
-
-    Ok(rc)
+    Ok(output.rc.unwrap_or_default())
 }
 
 pub fn recv_file(args: FileArgs) -> Result<(), String> {

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -403,7 +403,7 @@ fn parse_enclave_cid(args: &ArgMatches) -> NitroCliResult<Option<u64>> {
             ));
         }
 
-        if enclave_cid == u32::max_value() as u64 {
+        if enclave_cid == u32::MAX as u64 {
             return Err(new_nitro_cli_failure!(
                 &format!(
                     "CID {} is a well-known CID, not to be used for enclaves",
@@ -425,7 +425,7 @@ fn parse_enclave_cid(args: &ArgMatches) -> NitroCliResult<Option<u64>> {
         }
 
         // 64-bit CIDs are not yet supported for the vsock device.
-        if enclave_cid > u32::max_value() as u64 {
+        if enclave_cid > u32::MAX as u64 {
             return Err(new_nitro_cli_failure!(
                 &format!(
                     "CID {} is higher than the maximum supported (u32 max) for a vsock device",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -321,7 +321,7 @@ fn vsock_set_connect_timeout(fd: RawFd, millis: i64) -> NitroCliResult<()> {
 /// limit of enclave memory based on the EIF file size.
 pub fn ceil_div(lhs: u64, rhs: u64) -> u64 {
     if rhs == 0 {
-        return std::u64::MAX;
+        return u64::MAX;
     }
 
     lhs / rhs


### PR DESCRIPTION
**Description of changes:**
Resolving clippy error when building with Rust 1.79: https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
