### PR TITLE
Update sources for 1.3.2 release

### DIFF
--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-b7669679635964dc8b66cc947b35014825eade1d  nitro-cli-dependencies.tar.gz
+515afcdcab13c42aafccc9e2f32776a565dd51c0  nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
*Description of changes:*

Release 1.3.2 [1] misses OpenSSL dependency update for RPM spec [2]

[1]: https://github.com/eugkoira/aws-nitro-enclaves-cli/commit/f31ce847c930a13558b72c837329b8e635000b44
[2]: https://github.com/eugkoira/aws-nitro-enclaves-cli/commit/b7bdad82729f6ee03fbe788e7a1ffd708d97284d

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
