### PR TITLE
Update vsock_proxy cargo to rust version 1.71

### DIFF
--- a/vsock_proxy/Cargo.toml
+++ b/vsock_proxy/Cargo.toml
@@ -3,7 +3,7 @@ name = "vsock-proxy"
 version = "1.0.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
-rust-version = "1.68"
+rust-version = "1.71"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Update the rust-version to 1.71 from 1.68.

hickory-dns and some dependencies like litemap & tokio have versions that require 1.71+

Tried pining hickory-dns to `=0.24.0` but other various dependencies have the same problem.

```
error: package `hickory-resolver v0.24.2` cannot be built because it requires rustc 1.71.1 or newer, while the currently active rustc version is 1.68.2
Either upgrade to rustc 1.71.1 or newer, or use
cargo update -p hickory-resolver@0.24.2 --precise ver
where `ver` is the latest version of `hickory-resolver` supporting rustc 1.68.2
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
