### PR TITLE
Prepare 1.4.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "nitro-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "aws-nitro-enclaves-image-format",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitro-cli"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -20,7 +20,7 @@
 
 Summary:    AWS Nitro Enclaves tools for managing enclaves
 Name:       aws-nitro-enclaves-cli
-Version:    1.4.1
+Version:    1.4.2
 Release:    0%{?dist}
 
 License:    Apache 2.0
@@ -195,6 +195,9 @@ fi
 %{ne_include_dir}/*
 
 %changelog
+* Wed Mar 19 2025 Costin Lupu <lvpv@amazon.com> - 1.4.2-0
+- bump ring from 0.17.13 to 0.17.14
+
 * Tue Mar 18 2025 Costin Lupu <lvpv@amazon.com> - 1.4.1-0
 - build(deps): bump hickory-resolver from 0.24.2 to 0.24.4
 - build(deps): bump ring from 0.17.8 to 0.17.13

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (187)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (184)</li>
             <li><a href="#MIT">MIT License</a> (51)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (20)</li>
             <li><a href="#ISC">ISC License</a> (6)</li>
@@ -59,12 +59,6 @@
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.1.10</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.1</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-nitro-enclaves-cose ">aws-nitro-enclaves-cose 0.5.2</a></li>
-                    <li><a href=" https://github.com/aws/aws-nitro-enclaves-image-format ">aws-nitro-enclaves-image-format 0.5.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.1.9</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.2.7</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.4</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.60.12</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.60.7</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.7</a></li>
                     <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.7.3</a></li>
@@ -1724,7 +1718,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.4.1</a></li>
+                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.4.2</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -5699,7 +5693,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-lite ">regex-lite 0.1.6</a></li>
                     <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-syntax ">regex-syntax 0.8.5</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.11.1</a></li>
-                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.13</a></li>
+                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
                     <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                     <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.43</a></li>
                     <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs 0.6.3</a></li>
@@ -7197,6 +7191,11 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/awslabs/aws-nitro-enclaves-cose ">aws-nitro-enclaves-cose 0.5.2</a></li>
+                    <li><a href=" https://github.com/aws/aws-nitro-enclaves-image-format ">aws-nitro-enclaves-image-format 0.5.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.1.9</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.4</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.60.12</a></li>
                     <li><a href=" https://crates.io/crates/bollard-stubs ">bollard-stubs 1.44.0-rc.2</a></li>
                     <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.39</a></li>
                     <li><a href=" https://github.com/starkat99/half-rs ">half 1.8.3</a></li>
@@ -7329,16 +7328,6 @@ limitations under the License.
                     <li><a href=" https://github.com/paholg/typenum ">typenum 1.17.0</a></li>
                 </ul>
                 <pre class="license-text">MIT OR Apache-2.0</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/starkat99/half-rs ">half 1.8.3</a></li>
-                    <li><a href=" https://github.com/starkat99/half-rs ">half 2.4.1</a></li>
-                </ul>
-                <pre class="license-text">MIT OR Apache-2.0
-</pre>
             </li>
             <li class="license">
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
@@ -7515,7 +7504,7 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.13</a></li>
+                    <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
                 </ul>
                 <pre class="license-text">Copyright 2015-2025 Brian Smith.
 
@@ -8553,11 +8542,6 @@ THE SOFTWARE.
                     <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.7.4</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.7.6</a></li>
                     <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.14</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.5.5</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.7.5</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.7.5</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.5</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.5</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.10.3</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.10.4</a></li>
                 </ul>
@@ -8600,6 +8584,64 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Unicode-3.0">Unicode License v3</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.5.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.7.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.7.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.5</a></li>
+                </ul>
+                <pre class="license-text">UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 2020-2024 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the &quot;Data Files&quot;) or
+software and any associated documentation (the &quot;Software&quot;) to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
+
+—
+
+Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
+ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.
 </pre>
             </li>
         </ul>

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-a43634ef80a8ced611c336ea8353d05186b57fc8  nitro-cli-dependencies.tar.gz
+f88556b13bd05275581259b0da652d0aa8547f80  nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
Update nitro-cli version to 1.4.2.

- bump ring from 0.17.13 to 0.17.14


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
