### PR TITLE
Build PR builds in CodeBuild

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -1,6 +1,0 @@
-version: 0.0
-os: linux
-hooks:
-  AfterInstall:
-    - location: ci_entrypoint.sh
-      timeout: 3600

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
     commands:
       - echo Build started on `date`
       - env | grep CODEBUILD > build_env.txt
+      - $CODEBUILD_SRC_DIR/ci_entrypoint.sh
   post_build:
     commands:
       - echo Build completed on `date`


### PR DESCRIPTION
This commit updates CodeCommit spec to build the CI builds in CodeCommit instead of CodeDeploy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
