### PR TITLE
Resolve build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TOOLCHAIN_PREFIX = unknown-linux-musl
 HOST_MACHINE     = $(shell uname -m)
 
 CARGO   = cargo
-CC      = gcc
+CC      = musl-gcc
 INSTALL = install
 MKDIR   = mkdir
 RM      = rm
@@ -30,7 +30,6 @@ ifeq ($(HOST_MACHINE),$(ARCH_x86_64))
 TOOLCHAIN_ARCH_TARGET = $(ARCH_x86_64)
 else ifeq ($(HOST_MACHINE),$(ARCH_aarch64))
 TOOLCHAIN_ARCH_TARGET = $(ARCH_aarch64)
-CC = musl-gcc # Required for openssl-sys cross-build
 else
 TOOLCHAIN_ARCH_TARGET =
 endif

--- a/enclave_build/src/docker.rs
+++ b/enclave_build/src/docker.rs
@@ -354,27 +354,26 @@ mod tests {
     fn test_get_credentials() {
         let test_user = "test_user";
         let test_password = "test_password";
-        let auth = format!("{}:{}", test_user, test_password);
+        let auth = format!("{test_user}:{test_password}");
         let encoded_auth = general_purpose::STANDARD.encode(auth);
         let config = format!(
             r#"{{
             "auths": {{
               "https://public.ecr.aws/aws-nitro-enclaves/hello/v1/": {{
-                "auth": "{}"
+                "auth": "{encoded_auth}"
               }},
               "https://registry.example.com": {{
                 "auth": "b3RoZXJfdXNlcjpvdGhlcl9wYXNzd29yZA=="
               }}
             }}
-          }}"#,
-            encoded_auth
+          }}"#
         );
 
         // Create a temporary file
         let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file.");
 
         // Write the config to the temporary file
-        write!(temp_file, "{}", config).expect("Failed to write to temporary file.");
+        write!(temp_file, "{config}").expect("Failed to write to temporary file.");
 
         // Set the DOCKER_CONFIG environment variable to point to the temporary file's path
         let temp_file_path = temp_file.path().to_string_lossy().to_string();

--- a/enclave_build/src/lib.rs
+++ b/enclave_build/src/lib.rs
@@ -101,7 +101,7 @@ impl<'a> Docker2Eif<'a> {
         let sign_info = match (private_key, certificate_path) {
             (Some(key), Some(cert)) => SignKeyData::new(key, Path::new(&cert)).map_or_else(
                 |e| {
-                    eprintln!("Could not read signing info: {:?}", e);
+                    eprintln!("Could not read signing info: {e:?}");
                     None
                 },
                 Some,

--- a/samples/command_executer/src/command_parser.rs
+++ b/samples/command_executer/src/command_parser.rs
@@ -72,8 +72,8 @@ impl CommandOutput {
 
     pub fn new_from(output: Output) -> Result<Self, String> {
         Ok(CommandOutput {
-            stdout: String::from_utf8(output.stdout).map_err(|err| format!("{:?}", err))?,
-            stderr: String::from_utf8(output.stderr).map_err(|err| format!("{:?}", err))?,
+            stdout: String::from_utf8(output.stdout).map_err(|err| format!("{err:?}"))?,
+            stderr: String::from_utf8(output.stderr).map_err(|err| format!("{err:?}"))?,
             rc: output.status.code(),
         })
     }

--- a/samples/command_executer/src/protocol_helpers.rs
+++ b/samples/command_executer/src/protocol_helpers.rs
@@ -33,14 +33,14 @@ pub fn recv_i32(fd: RawFd) -> Result<i32, String> {
 }
 
 pub fn send_loop(fd: RawFd, buf: &[u8], len: u64) -> Result<(), String> {
-    let len: usize = len.try_into().map_err(|err| format!("{:?}", err))?;
+    let len: usize = len.try_into().map_err(|err| format!("{err:?}"))?;
     let mut send_bytes = 0;
 
     while send_bytes < len {
         let size = match send(fd, &buf[send_bytes..len], MsgFlags::empty()) {
             Ok(size) => size,
             Err(nix::errno::Errno::EINTR) => 0,
-            Err(err) => return Err(format!("{:?}", err)),
+            Err(err) => return Err(format!("{err:?}")),
         };
         send_bytes += size;
     }
@@ -49,7 +49,7 @@ pub fn send_loop(fd: RawFd, buf: &[u8], len: u64) -> Result<(), String> {
 }
 
 pub fn recv_loop(fd: RawFd, buf: &mut [u8], len: u64) -> Result<(), String> {
-    let len: usize = len.try_into().map_err(|err| format!("{:?}", err))?;
+    let len: usize = len.try_into().map_err(|err| format!("{err:?}"))?;
     let mut recv_bytes = 0;
 
     while recv_bytes < len {
@@ -57,7 +57,7 @@ pub fn recv_loop(fd: RawFd, buf: &mut [u8], len: u64) -> Result<(), String> {
             Ok(0) => return Err(format!("{:?}", "Peer closed connection")),
             Ok(size) => size,
             Err(nix::errno::Errno::EINTR) => 0,
-            Err(err) => return Err(format!("{:?}", err)),
+            Err(err) => return Err(format!("{err:?}")),
         };
         recv_bytes += size;
     }

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -45,7 +45,7 @@ impl RunEnclavesArgs {
         if let Some(config_file) = args.get_one::<String>("config") {
             let file = File::open(config_file).map_err(|err| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to open config file: {:?}", err),
+                    &format!("Failed to open config file: {err:?}"),
                     NitroCliErrorEnum::FileOperationFailure
                 )
                 .add_info(vec![config_file, "Open"])
@@ -53,7 +53,7 @@ impl RunEnclavesArgs {
 
             let mut json: RunEnclavesArgs = serde_json::from_reader(file).map_err(|err| {
                 new_nitro_cli_failure!(
-                    &format!("Invalid JSON format for config file: {:?}", err),
+                    &format!("Invalid JSON format for config file: {err:?}"),
                     NitroCliErrorEnum::SerdeError
                 )
             })?;
@@ -400,20 +400,14 @@ fn parse_enclave_cid(args: &ArgMatches) -> NitroCliResult<Option<u64>> {
 
         if enclave_cid > 0 && enclave_cid <= VMADDR_CID_HOST as u64 {
             return Err(new_nitro_cli_failure!(
-                &format!(
-                    "CID {} is a well-known CID, not to be used for enclaves",
-                    enclave_cid
-                ),
+                &format!("CID {enclave_cid} is a well-known CID, not to be used for enclaves"),
                 NitroCliErrorEnum::InvalidArgument
             ));
         }
 
         if enclave_cid == u32::MAX as u64 {
             return Err(new_nitro_cli_failure!(
-                &format!(
-                    "CID {} is a well-known CID, not to be used for enclaves",
-                    enclave_cid
-                ),
+                &format!("CID {enclave_cid} is a well-known CID, not to be used for enclaves"),
                 NitroCliErrorEnum::InvalidArgument
             ));
         }
@@ -422,8 +416,7 @@ fn parse_enclave_cid(args: &ArgMatches) -> NitroCliResult<Option<u64>> {
         if enclave_cid == VMADDR_CID_PARENT as u64 {
             return Err(new_nitro_cli_failure!(
                 &format!(
-                    "CID {} is the CID of the parent VM, not to be used for enclaves",
-                    enclave_cid
+                    "CID {enclave_cid} is the CID of the parent VM, not to be used for enclaves"
                 ),
                 NitroCliErrorEnum::InvalidArgument
             ));
@@ -433,8 +426,7 @@ fn parse_enclave_cid(args: &ArgMatches) -> NitroCliResult<Option<u64>> {
         if enclave_cid > u32::MAX as u64 {
             return Err(new_nitro_cli_failure!(
                 &format!(
-                    "CID {} is higher than the maximum supported (u32 max) for a vsock device",
-                    enclave_cid
+                    "CID {enclave_cid} is higher than the maximum supported (u32 max) for a vsock device"
                 ),
                 NitroCliErrorEnum::InvalidArgument
             ));

--- a/src/common/document_errors.rs
+++ b/src/common/document_errors.rs
@@ -74,7 +74,7 @@ lazy_static! {
 
 /// Returns detailed error information based on supplied arguments.
 pub fn get_detailed_info(error_code_str: String, additional_info: &[String]) -> String {
-    let mut ret = format!("[ {} ] ", error_code_str);
+    let mut ret = format!("[ {error_code_str} ] ");
     let info_placeholder = "MISSING_INFO".to_string();
 
     match error_code_str.as_str() {
@@ -338,7 +338,7 @@ pub fn get_detailed_info(error_code_str: String, additional_info: &[String]) -> 
             ret.push_str("Signing error. Such error appears if incorrect key or certificate paths are provided, or when AWS credenrials need to be refreshed to use a KMS key.");
         }
         _ => {
-            ret.push_str(format!("No such error code {}", error_code_str).as_str());
+            ret.push_str(format!("No such error code {error_code_str}").as_str());
         }
     }
 
@@ -347,10 +347,7 @@ pub fn get_detailed_info(error_code_str: String, additional_info: &[String]) -> 
 
 /// Returns a link with more detailed information regarding a specific error.
 pub fn construct_help_link(error_code_str: String) -> String {
-    format!(
-        "https://docs.aws.amazon.com/enclaves/latest/user/cli-errors.html#{}",
-        error_code_str
-    )
+    format!("https://docs.aws.amazon.com/enclaves/latest/user/cli-errors.html#{error_code_str}")
 }
 
 /// Returns a string containing the backtrace recorded during propagating an error message
@@ -360,7 +357,7 @@ pub fn construct_backtrace(failure_info: &NitroCliFailure) -> String {
     format!("  Action: {}\n  Subactions:{}\n  Root error file: {}\n  Root error line: {}\n  Version: {}",
         failure_info.action,
         failure_info.subactions.iter().rev().fold("".to_string(), |acc, x| {
-            format!("{}\n    {}", acc, x)
+            format!("{acc}\n    {x}")
         }),
         failure_info.file,
         failure_info.line,
@@ -551,7 +548,7 @@ pub fn explain_error(error_code_str: String) {
             eprintln!("Signing error. Such error appears if incorrect key or certificate paths are provided, or when AWS credenrials need to be refreshed to use a KMS key.");
         }
         _ => {
-            eprintln!("No such error code {}", error_code_str);
+            eprintln!("No such error code {error_code_str}");
         }
     }
 }

--- a/src/common/logger.rs
+++ b/src/common/logger.rs
@@ -62,7 +62,7 @@ impl EnclaveProcLogWriter {
                 .map_err(|e| e.add_subaction(String::from("Failed to open log file")))?;
             let mut file_ref = self.out_file.lock().map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to acquire lock: {:?}", e),
+                    &format!("Failed to acquire lock: {e:?}"),
                     NitroCliErrorEnum::LockAcquireFailure
                 )
             })?;
@@ -76,7 +76,7 @@ impl EnclaveProcLogWriter {
     pub fn update_logger_id(&self, new_id: &str) -> NitroCliResult<()> {
         let mut old_id = self.logger_id.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire logger ID lock: {:?}", e),
+                &format!("Failed to acquire logger ID lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -93,7 +93,7 @@ impl EnclaveProcLogWriter {
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
         let logger_id = self.logger_id.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire logger ID lock: {:?}", e),
+                &format!("Failed to acquire logger ID lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -175,7 +175,7 @@ fn open_log_file(file_path: &Path) -> NitroCliResult<File> {
         .open(file_path)
         .map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to open log file: {:?}", e),
+                &format!("Failed to open log file: {e:?}"),
                 NitroCliErrorEnum::FileOperationFailure
             )
             .add_info(vec![
@@ -190,7 +190,7 @@ fn open_log_file(file_path: &Path) -> NitroCliResult<File> {
         file.metadata()
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to get log file metadata: {:?}", e),
+                    &format!("Failed to get log file metadata: {e:?}"),
                     NitroCliErrorEnum::FileOperationFailure
                 )
                 .add_info(vec![
@@ -210,7 +210,7 @@ fn open_log_file(file_path: &Path) -> NitroCliResult<File> {
         let perms = Permissions::from_mode(0o766);
         file.set_permissions(perms).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to change log file permissions: {:?}", e),
+                &format!("Failed to change log file permissions: {e:?}"),
                 NitroCliErrorEnum::FilePermissionsError
             )
         })?;
@@ -228,7 +228,7 @@ pub fn init_logger() -> NitroCliResult<EnclaveProcLogWriter> {
     flexi_logger::Logger::try_with_env_or_str(DEFAULT_LOG_LEVEL)
         .map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to initialize enclave process logger: {:?}", e),
+                &format!("Failed to initialize enclave process logger: {e:?}"),
                 NitroCliErrorEnum::LoggerError
             )
         })?
@@ -236,7 +236,7 @@ pub fn init_logger() -> NitroCliResult<EnclaveProcLogWriter> {
         .start()
         .map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to initialize enclave process logger: {:?}", e),
+                &format!("Failed to initialize enclave process logger: {e:?}"),
                 NitroCliErrorEnum::LoggerError
             )
         })?;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -363,41 +363,31 @@ pub fn construct_error_message(failure: &NitroCliFailure) -> String {
             "1" => {
                 if let Ok(log_path) = log_path {
                     format!(
-                        "{}\n\nFor more details, please visit {}\n\nBacktrace:\n{}\n\nIf you open a support ticket, please provide the error log found at \"{}\"",
-                        error_info, help_link, backtrace, log_path
+                        "{error_info}\n\nFor more details, please visit {help_link}\n\nBacktrace:\n{backtrace}\n\nIf you open a support ticket, please provide the error log found at \"{log_path}\""
                     )
                 } else {
                     format!(
-                        "{}\n\nFor more details, please visit {}\n\nBacktrace:\n{}",
-                        error_info, help_link, backtrace
+                        "{error_info}\n\nFor more details, please visit {help_link}\n\nBacktrace:\n{backtrace}"
                     )
                 }
             }
             _ => {
                 if let Ok(log_path) = log_path {
                     format!(
-                        "{}\n\nFor more details, please visit {}\n\nIf you open a support ticket, please provide the error log found at \"{}\"",
-                        error_info, help_link, log_path
+                        "{error_info}\n\nFor more details, please visit {help_link}\n\nIf you open a support ticket, please provide the error log found at \"{log_path}\""
                     )
                 } else {
-                    format!(
-                        "{}\n\nFor more details, please visit {}",
-                        error_info, help_link
-                    )
+                    format!("{error_info}\n\nFor more details, please visit {help_link}")
                 }
             }
         },
         _ => {
             if let Ok(log_path) = log_path {
                 format!(
-                    "{}\n\nFor more details, please visit {}\n\nIf you open a support ticket, please provide the error log found at \"{}\"",
-                    error_info, help_link, log_path
+                    "{error_info}\n\nFor more details, please visit {help_link}\n\nIf you open a support ticket, please provide the error log found at \"{log_path}\""
                 )
             } else {
-                format!(
-                    "{}\n\nFor more details, please visit {}",
-                    error_info, help_link
-                )
+                format!("{error_info}\n\nFor more details, please visit {help_link}")
             }
         }
     }
@@ -418,7 +408,7 @@ impl<T> ExitGracefully<T> for NitroCliResult<T> {
             Err(err) => {
                 let err_str = construct_error_message(&err);
                 if let Some(additional_info_str) = additional_info {
-                    notify_error(&format!("{} | {}", additional_info_str, err_str));
+                    notify_error(&format!("{additional_info_str} | {err_str}"));
                 } else {
                     notify_error(&err_str);
                 }
@@ -430,7 +420,7 @@ impl<T> ExitGracefully<T> for NitroCliResult<T> {
 
 /// Notify both the user and the logger of an error.
 pub fn notify_error(err_msg: &str) {
-    eprintln!("{}", err_msg);
+    eprintln!("{err_msg}");
     error!("{}", err_msg);
 }
 
@@ -479,7 +469,7 @@ where
     let mut cmd_bytes = Vec::new();
     ciborium::ser::into_writer(&cmd, &mut cmd_bytes).map_err(|e| {
         new_nitro_cli_failure!(
-            &format!("Invalid command format: {:?}", e),
+            &format!("Invalid command format: {e:?}"),
             NitroCliErrorEnum::InvalidCommand
         )
     })?;
@@ -491,7 +481,7 @@ where
             .map_err(|e| e.add_subaction("Failed to send single command size".to_string()))?;
         socket.write_all(&cmd_bytes[..]).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to send single command: {:?}", e),
+                &format!("Failed to send single command: {e:?}"),
                 NitroCliErrorEnum::SocketError
             )
         })?;
@@ -502,7 +492,7 @@ where
         let mut arg_bytes = Vec::new();
         ciborium::ser::into_writer(args, &mut arg_bytes).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Invalid single command arguments: {:?}", e),
+                &format!("Invalid single command arguments: {e:?}"),
                 NitroCliErrorEnum::InvalidCommand
             )
         })?;
@@ -512,7 +502,7 @@ where
             .map_err(|e| e.add_subaction("Failed to send arguments size".to_string()))?;
         socket.write_all(&arg_bytes).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to send arguments: {:?}", e),
+                &format!("Failed to send arguments: {e:?}"),
                 NitroCliErrorEnum::SocketError
             )
         })?;
@@ -533,7 +523,7 @@ where
     let data: T =
         ciborium::de::from_reader_with_buffer(input_stream, &mut raw_data[..]).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to decode received data: {:?}", e),
+                &format!("Failed to decode received data: {e:?}"),
                 NitroCliErrorEnum::SerdeError
             )
         })?;

--- a/src/common/signal_handler.rs
+++ b/src/common/signal_handler.rs
@@ -40,7 +40,7 @@ impl SignalHandler {
         if let Some(set) = self.sig_set {
             set.thread_block().map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Masking signals covered by handler failed: {:?}", e),
+                    &format!("Masking signals covered by handler failed: {e:?}"),
                     NitroCliErrorEnum::SignalMaskingError
                 )
             })?;
@@ -54,7 +54,7 @@ impl SignalHandler {
         if let Some(set) = self.sig_set {
             set.thread_unblock().map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Unmasking signals covered by handler failed: {:?}", e),
+                    &format!("Unmasking signals covered by handler failed: {e:?}"),
                     NitroCliErrorEnum::SignalUnmaskingError
                 )
             })?;

--- a/src/enclave_proc/commands.rs
+++ b/src/enclave_proc/commands.rs
@@ -51,7 +51,7 @@ pub fn run_enclaves(
 
     let eif_file = File::open(&args.eif_path).map_err(|e| {
         new_nitro_cli_failure!(
-            &format!("Failed to open the EIF file: {:?}", e),
+            &format!("Failed to open the EIF file: {e:?}"),
             NitroCliErrorEnum::FileOperationFailure
         )
         .add_info(vec![&args.eif_path, "Open"])
@@ -86,7 +86,7 @@ pub fn run_enclaves(
 
     let mut signature_checker = PcrSignatureChecker::from_eif(&args.eif_path).map_err(|e| {
         new_nitro_cli_failure!(
-            &format!("Failed to create EIF signature checker: {:?}", e),
+            &format!("Failed to create EIF signature checker: {e:?}"),
             NitroCliErrorEnum::EIFSignatureCheckerError
         )
     })?;
@@ -95,7 +95,7 @@ pub fn run_enclaves(
     if !signature_checker.is_empty() {
         signature_checker.verify().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Invalid signing certificate: {:?}", e),
+                &format!("Invalid signing certificate: {e:?}"),
                 NitroCliErrorEnum::EIFSignatureCheckerError
             )
         })?;
@@ -106,7 +106,7 @@ pub fn run_enclaves(
     let handle = std::thread::spawn(move || {
         let mut eif_reader = EifReader::from_eif(path).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed initialize EIF reader: {:?}", e),
+                &format!("Failed initialize EIF reader: {e:?}"),
                 NitroCliErrorEnum::EifParsingError
             )
         })?;
@@ -120,7 +120,7 @@ pub fn run_enclaves(
         )
         .map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to calculate PCRs: {:?}", e),
+                &format!("Failed to calculate PCRs: {e:?}"),
                 NitroCliErrorEnum::EifParsingError
             )
         })?;
@@ -183,7 +183,7 @@ pub fn terminate_enclaves(
         serde_json::to_string_pretty(&EnclaveTerminateInfo::new(enclave_name, enclave_id, true))
             .map_err(|err| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to display enclave termination data: {:?}", err),
+                    &format!("Failed to display enclave termination data: {err:?}"),
                     NitroCliErrorEnum::SerdeError
                 )
             })?
@@ -206,7 +206,7 @@ pub fn describe_enclaves(
         serde_json::to_string_pretty(&info)
             .map_err(|err| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to display enclave describe data: {:?}", err),
+                    &format!("Failed to display enclave describe data: {err:?}"),
                     NitroCliErrorEnum::SerdeError
                 )
             })?

--- a/src/enclave_proc/connection.rs
+++ b/src/enclave_proc/connection.rs
@@ -61,7 +61,7 @@ impl Drop for ConnectionData {
                 .shutdown(std::net::Shutdown::Both)
                 .map_err(|e| {
                     new_nitro_cli_failure!(
-                        &format!("Stream shutdown error: {:?}", e),
+                        &format!("Stream shutdown error: {e:?}"),
                         NitroCliErrorEnum::SocketCloseError
                     )
                 })
@@ -162,7 +162,7 @@ impl Connection {
     pub fn read_command(&self) -> NitroCliResult<EnclaveProcessCommandType> {
         let mut lock = self.data.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -219,7 +219,7 @@ impl Connection {
     {
         let mut lock = self.data.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -237,7 +237,7 @@ impl Connection {
     pub fn write_u64(&self, value: u64) -> NitroCliResult<()> {
         let mut lock = self.data.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -283,7 +283,7 @@ impl Connection {
     pub fn get_enclave_event_flags(&self) -> NitroCliResult<Option<EpollFlags>> {
         let lock = self.data.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire connection lock: {:?}", e),
+                &format!("Failed to acquire connection lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -297,7 +297,7 @@ impl Connection {
     fn write_reply(&self, reply: &EnclaveProcessReply) -> NitroCliResult<()> {
         let mut lock = self.data.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -312,7 +312,7 @@ impl Connection {
         let mut reply_bytes = Vec::new();
         ciborium::into_writer(reply, &mut reply_bytes).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to serialize reply: {:?}", e),
+                &format!("Failed to serialize reply: {e:?}"),
                 NitroCliErrorEnum::SerdeError
             )
         })?;
@@ -321,7 +321,7 @@ impl Connection {
             .map_err(|e| e.add_subaction("Write reply".to_string()))?;
         stream.write_all(&reply_bytes).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to write to stream: {:?}", e),
+                &format!("Failed to write to stream: {e:?}"),
                 NitroCliErrorEnum::SocketError
             )
         })

--- a/src/enclave_proc/connection_listener.rs
+++ b/src/enclave_proc/connection_listener.rs
@@ -55,7 +55,7 @@ impl ConnectionListener {
         Ok(ConnectionListener {
             epoll_fd: epoll::epoll_create().map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to initialize epoll: {:?}", e),
+                    &format!("Failed to initialize epoll: {e:?}"),
                     NitroCliErrorEnum::EpollError
                 )
             })?,
@@ -78,7 +78,7 @@ impl ConnectionListener {
         // Bind the listener to the socket and spawn the listener thread.
         let listener = UnixListener::bind(self.socket.get_path()).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to bind connection listener: {:?}", e),
+                &format!("Failed to bind connection listener: {e:?}"),
                 NitroCliErrorEnum::SocketError
             )
         })?;
@@ -112,7 +112,7 @@ impl ConnectionListener {
         epoll::epoll_ctl(self.epoll_fd, EpollOp::EpollCtlAdd, stream_fd, &mut cli_evt).map_err(
             |e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to add stream to epoll: {:?}", e),
+                    &format!("Failed to add stream to epoll: {e:?}"),
                     NitroCliErrorEnum::EpollError
                 )
             },
@@ -130,7 +130,7 @@ impl ConnectionListener {
         epoll::epoll_ctl(self.epoll_fd, EpollOp::EpollCtlAdd, enc_fd, &mut enc_event).map_err(
             |e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to add enclave descriptor to epoll: {:?}", e),
+                    &format!("Failed to add enclave descriptor to epoll: {e:?}"),
                     NitroCliErrorEnum::EpollError
                 )
             },
@@ -198,7 +198,7 @@ impl ConnectionListener {
         // Send termination notification to the listener thread.
         let mut self_conn = UnixStream::connect(self.socket.get_path()).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to connect to listener thread: {:?}", e),
+                &format!("Failed to connect to listener thread: {e:?}"),
                 NitroCliErrorEnum::SocketError
             )
         })?;
@@ -212,7 +212,7 @@ impl ConnectionListener {
         // Shut the connection down.
         self_conn.shutdown(std::net::Shutdown::Both).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to close connection: {:?}", e),
+                &format!("Failed to close connection: {e:?}"),
                 NitroCliErrorEnum::SocketCloseError
             )
         })?;
@@ -220,7 +220,7 @@ impl ConnectionListener {
         // Ensure that the listener thread has terminated.
         self.listener_thread.take().unwrap().join().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to join listener thread: {:?}", e),
+                &format!("Failed to join listener thread: {e:?}"),
                 NitroCliErrorEnum::ThreadJoinFailure
             )
         })?;
@@ -239,7 +239,7 @@ impl ConnectionListener {
                 Err(nix::errno::Errno::EINTR) => continue,
                 Err(e) => {
                     return Err(new_nitro_cli_failure!(
-                        &format!("Failed to wait on epoll: {:?}", e),
+                        &format!("Failed to wait on epoll: {e:?}"),
                         NitroCliErrorEnum::EpollError
                     ))
                 }
@@ -259,7 +259,7 @@ impl ConnectionListener {
         // the Connection not touch epoll directly.
         epoll::epoll_ctl(self.epoll_fd, EpollOp::EpollCtlDel, fd, None).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to remove descriptor from epoll: {:?}", e),
+                &format!("Failed to remove descriptor from epoll: {e:?}"),
                 NitroCliErrorEnum::EpollError
             )
         })?;
@@ -445,13 +445,13 @@ mod tests {
 
             // Bind the listener to the socket and spawn the listener thread.
             let listener = UnixListener::bind(connection_listener.socket.get_path())
-                .map_err(|e| format!("Failed to bind connection listener: {:?}", e))
+                .map_err(|e| format!("Failed to bind connection listener: {e:?}"))
                 .unwrap();
             connection_listener.enable_credentials_passing(&listener);
             connection_listener
                 .socket
                 .start_monitoring(true)
-                .map_err(|e| format!("Failed to start socket monitoring: {:?}", e))
+                .map_err(|e| format!("Failed to start socket monitoring: {e:?}"))
                 .unwrap();
 
             let res = connection_listener.connection_listener_run(listener);
@@ -564,13 +564,13 @@ mod tests {
 
             // Bind the listener to the socket and spawn the listener thread.
             let listener = UnixListener::bind(connection_listener.socket.get_path())
-                .map_err(|e| format!("Failed to bind connection listener: {:?}", e))
+                .map_err(|e| format!("Failed to bind connection listener: {e:?}"))
                 .unwrap();
             connection_listener.enable_credentials_passing(&listener);
             connection_listener
                 .socket
                 .start_monitoring(true)
-                .map_err(|e| format!("Failed to start socket monitoring: {:?}", e))
+                .map_err(|e| format!("Failed to start socket monitoring: {e:?}"))
                 .unwrap();
 
             conn_clone.connection_listener_run(listener).unwrap();

--- a/src/enclave_proc/cpu_info.rs
+++ b/src/enclave_proc/cpu_info.rs
@@ -41,7 +41,7 @@ impl CpuInfo {
     pub fn new() -> NitroCliResult<Self> {
         let pool_file = File::open(POOL_FILENAME).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to open CPU pool file: {}", e),
+                &format!("Failed to open CPU pool file: {e}"),
                 NitroCliErrorEnum::FileOperationFailure
             )
             .add_info(vec![POOL_FILENAME, "Open"])
@@ -113,10 +113,7 @@ impl CpuInfo {
         for cpu_id in unique_ids {
             if !self.cpu_ids.contains(cpu_id) {
                 return Err(new_nitro_cli_failure!(
-                    &format!(
-                        "The CPU with ID {} is not available in the NE CPU pool",
-                        cpu_id
-                    ),
+                    &format!("The CPU with ID {cpu_id} is not available in the NE CPU pool"),
                     NitroCliErrorEnum::NoSuchCpuAvailableInPool
                 )
                 .add_info(vec!["cpu-ids", &cpu_id.to_string()]));
@@ -138,7 +135,7 @@ impl CpuInfo {
         line_str.retain(|c| !c.is_whitespace());
         line_str.parse::<u32>().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to parse CPU ID: {}", e),
+                &format!("Failed to parse CPU ID: {e}"),
                 NitroCliErrorEnum::MalformedCpuId
             )
         })
@@ -162,7 +159,7 @@ impl CpuInfo {
                 }
                 _ => {
                     return Err(new_nitro_cli_failure!(
-                        &format!("Invalid CPU ID interval ({})", interval),
+                        &format!("Invalid CPU ID interval ({interval})"),
                         NitroCliErrorEnum::CpuError
                     ))
                 }
@@ -179,7 +176,7 @@ impl CpuInfo {
         for line in reader.lines() {
             let line_str = line.map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to read line from CPU pool file: {}", e),
+                    &format!("Failed to read line from CPU pool file: {e}"),
                     NitroCliErrorEnum::FileOperationFailure
                 )
                 .add_info(vec![POOL_FILENAME, "Read"])

--- a/src/enclave_proc/mod.rs
+++ b/src/enclave_proc/mod.rs
@@ -86,7 +86,7 @@ fn send_command_and_close(cmd: EnclaveProcessCommandType, stream: &mut UnixStrea
         .shutdown(std::net::Shutdown::Both)
         .map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to close stream after sending command: {:?}", e),
+                &format!("Failed to close stream after sending command: {e:?}"),
                 NitroCliErrorEnum::SocketCloseError
             )
             .set_action(action_str.to_string())
@@ -133,7 +133,7 @@ fn notify_terminate(
 ) -> NitroCliResult<JoinHandle<()>> {
     let (local_stream, thread_stream) = UnixStream::pair().map_err(|e| {
         new_nitro_cli_failure!(
-            &format!("Could not create stream pair: {:?}", e),
+            &format!("Could not create stream pair: {e:?}"),
             NitroCliErrorEnum::SocketPairCreationFailure
         )
     })?;
@@ -152,7 +152,7 @@ fn enclave_proc_configure_signal_handler(conn_listener: &ConnectionListener) -> 
     let (local_stream, thread_stream) = UnixStream::pair()
         .map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to create stream pair: {:?}", e),
+                &format!("Failed to create stream pair: {e:?}"),
                 NitroCliErrorEnum::SocketPairCreationFailure
             )
             .set_action("Run Enclave".to_string())
@@ -227,7 +227,7 @@ fn fetch_describe_result(
             .join()
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Termination thread join failed: {:?}", e),
+                    &format!("Termination thread join failed: {e:?}"),
                     NitroCliErrorEnum::ThreadJoinFailure
                 )
             })?
@@ -352,7 +352,7 @@ fn handle_command(
                 serde_json::to_string_pretty(&enclave_manager.enclave_name)
                     .map_err(|err| {
                         new_nitro_cli_failure!(
-                            &format!("Failed to write enclave name to connection: {:?}", err),
+                            &format!("Failed to write enclave name to connection: {err:?}"),
                             NitroCliErrorEnum::SerdeError
                         )
                     })?
@@ -378,7 +378,7 @@ fn handle_command(
                     serde_json::to_string_pretty(&enclave_manager.enclave_id)
                         .map_err(|err| {
                             new_nitro_cli_failure!(
-                                &format!("Failed to display RunEnclaves data: {:?}", err),
+                                &format!("Failed to display RunEnclaves data: {err:?}"),
                                 NitroCliErrorEnum::SerdeError
                             )
                         })?
@@ -493,7 +493,7 @@ fn process_event_loop(
             Err(mut error_info) => {
                 // Any encountered error is both logged and send to the other side of the connection.
                 error_info = error_info
-                    .add_subaction(format!("Failed to execute command `{:?}`", cmd))
+                    .add_subaction(format!("Failed to execute command `{cmd:?}`"))
                     .set_action("Run Enclave".to_string());
                 notify_error_with_conn(&construct_error_message(&error_info), &connection, cmd);
                 (libc::EINVAL, true)
@@ -513,7 +513,7 @@ fn process_event_loop(
             if terminate_thread.is_some() {
                 terminate_thread.take().unwrap().join().map_err(|e| {
                     new_nitro_cli_failure!(
-                        &format!("Termination thread join failed: {:?}", e),
+                        &format!("Termination thread join failed: {e:?}"),
                         NitroCliErrorEnum::ThreadJoinFailure
                     )
                 })?;
@@ -559,7 +559,7 @@ fn create_enclave_process(logger: &EnclaveProcLogWriter) -> NitroCliResult<()> {
     // unchanged and the standard descriptors are routed to '/dev/null'.
     daemon(true, false).map_err(|e| {
         new_nitro_cli_failure!(
-            &format!("Failed to daemonize enclave process: {:?}", e),
+            &format!("Failed to daemonize enclave process: {e:?}"),
             NitroCliErrorEnum::DaemonizeProcessFailure
         )
     })?;

--- a/src/enclave_proc/resource_manager.rs
+++ b/src/enclave_proc/resource_manager.rs
@@ -206,10 +206,7 @@ impl MemoryRegion {
             .position(|&page_info| page_info.0 == hugepage_flag)
             .ok_or_else(|| {
                 new_nitro_cli_failure!(
-                    &format!(
-                        "Failed to find huge page entry for flag {:X?}",
-                        hugepage_flag
-                    ),
+                    &format!("Failed to find huge page entry for flag {hugepage_flag:X?}"),
                     NitroCliErrorEnum::NoSuchHugepageFlag
                 )
             })?;
@@ -302,7 +299,7 @@ impl MemoryRegion {
         file.read_exact(&mut bytes[region_offset..region_offset + size])
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Error while reading from enclave image: {:?}", e),
+                    &format!("Error while reading from enclave image: {e:?}"),
                     NitroCliErrorEnum::EifParsingError
                 )
             })?;
@@ -482,7 +479,7 @@ impl EnclaveHandle {
             .metadata()
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to get enclave image file metadata: {:?}", e),
+                    &format!("Failed to get enclave image file metadata: {e:?}"),
                     NitroCliErrorEnum::FileOperationFailure
                 )
             })?
@@ -511,7 +508,7 @@ impl EnclaveHandle {
             .open(NE_DEV_FILEPATH)
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to open device file: {:?}", e),
+                    &format!("Failed to open device file: {e:?}"),
                     NitroCliErrorEnum::FileOperationFailure
                 )
                 .add_info(vec![NE_DEV_FILEPATH, "Open"])
@@ -524,7 +521,7 @@ impl EnclaveHandle {
 
         if enc_fd < 0 {
             return Err(new_nitro_cli_failure!(
-                &format!("Invalid enclave file descriptor ({})", enc_fd),
+                &format!("Invalid enclave file descriptor ({enc_fd})"),
                 NitroCliErrorEnum::InvalidEnclaveFd
             ));
         }
@@ -582,7 +579,7 @@ impl EnclaveHandle {
             .metadata()
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to get enclave image file metadata: {:?}", e),
+                    &format!("Failed to get enclave image file metadata: {e:?}"),
                     NitroCliErrorEnum::FileOperationFailure
                 )
             })?
@@ -592,7 +589,7 @@ impl EnclaveHandle {
         let poll_timeout = calculate_necessary_timeout(eif_size, self.allocated_memory_mib * MiB);
 
         enclave_ready(listener, poll_timeout).map_err(|err| {
-            let err_msg = format!("Waiting on enclave to boot failed with error {:?}", err);
+            let err_msg = format!("Waiting on enclave to boot failed with error {err:?}");
             self.terminate_enclave_error(&err_msg);
             new_nitro_cli_failure!(&err_msg, NitroCliErrorEnum::EnclaveBootFailure)
         })?;
@@ -613,7 +610,7 @@ impl EnclaveHandle {
             serde_json::to_string_pretty(&info)
                 .map_err(|err| {
                     new_nitro_cli_failure!(
-                        &format!("Failed to display RunEnclaves data: {:?}", err),
+                        &format!("Failed to display RunEnclaves data: {err:?}"),
                         NitroCliErrorEnum::SerdeError
                     )
                 })?
@@ -699,7 +696,7 @@ impl EnclaveHandle {
             EnclaveCpuConfig::List(cpu_ids) => {
                 for cpu_id in cpu_ids {
                     self.init_single_cpu(cpu_id).map_err(|e| {
-                        e.add_subaction(format!("Failed to add CPU with ID {}", cpu_id))
+                        e.add_subaction(format!("Failed to add CPU with ID {cpu_id}"))
                     })?;
                 }
             }
@@ -785,7 +782,7 @@ impl EnclaveHandle {
 
     /// Terminate the enclave if `run-enclave` failed.
     fn terminate_enclave_error(&mut self, err: &str) {
-        let err_msg = format!("{}. Terminating the enclave...", err);
+        let err_msg = format!("{err}. Terminating the enclave...");
 
         // Notify the user and the logger of the error, then terminate the enclave.
         notify_error(&err_msg);
@@ -856,7 +853,7 @@ impl EnclaveHandle {
                 "The provided enclave CID is invalid, being a well-known CID or the parent VM CID"
                     .to_string()
             }
-            e => format!("An error has occurred: {} (rc: {})", e, rc),
+            e => format!("An error has occurred: {e} (rc: {rc})"),
         };
 
         Err(new_nitro_cli_failure!(
@@ -909,7 +906,7 @@ impl EnclaveManager {
             .lock()
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to acquire lock: {:?}", e),
+                    &format!("Failed to acquire lock: {e:?}"),
                     NitroCliErrorEnum::LockAcquireFailure
                 )
             })?
@@ -927,7 +924,7 @@ impl EnclaveManager {
             .lock()
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to acquire lock: {:?}", e),
+                    &format!("Failed to acquire lock: {e:?}"),
                     NitroCliErrorEnum::LockAcquireFailure
                 )
             })?
@@ -941,7 +938,7 @@ impl EnclaveManager {
             .lock()
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to acquire lock: {:?}", e),
+                    &format!("Failed to acquire lock: {e:?}"),
                     NitroCliErrorEnum::LockAcquireFailure
                 )
             })?
@@ -955,7 +952,7 @@ impl EnclaveManager {
     pub fn get_description_resources(&self) -> NitroCliResult<UnpackedHandle> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -974,7 +971,7 @@ impl EnclaveManager {
     pub fn get_measurements(&self) -> NitroCliResult<EnclaveBuildInfo> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -985,7 +982,7 @@ impl EnclaveManager {
     pub fn get_metadata(&self) -> NitroCliResult<Option<EifIdentityInfo>> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -998,7 +995,7 @@ impl EnclaveManager {
     pub fn get_console_resources_enclave_cid(&self) -> NitroCliResult<u64> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -1011,7 +1008,7 @@ impl EnclaveManager {
     pub fn get_console_resources_enclave_flags(&self) -> NitroCliResult<u64> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -1024,7 +1021,7 @@ impl EnclaveManager {
     fn get_termination_resources(&self) -> NitroCliResult<(RawFd, ResourceAllocator)> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -1040,7 +1037,7 @@ impl EnclaveManager {
     pub fn get_enclave_descriptor(&self) -> NitroCliResult<RawFd> {
         let locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -1053,7 +1050,7 @@ impl EnclaveManager {
     pub fn update_state(&mut self, state: EnclaveState) -> NitroCliResult<()> {
         let mut locked_handle = self.enclave_handle.lock().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to acquire lock: {:?}", e),
+                &format!("Failed to acquire lock: {e:?}"),
                 NitroCliErrorEnum::LockAcquireFailure
             )
         })?;
@@ -1080,7 +1077,7 @@ impl EnclaveManager {
             .lock()
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to acquire lock: {:?}", e),
+                    &format!("Failed to acquire lock: {e:?}"),
                     NitroCliErrorEnum::LockAcquireFailure
                 )
             })?

--- a/src/enclave_proc/socket.rs
+++ b/src/enclave_proc/socket.rs
@@ -77,7 +77,7 @@ impl EnclaveProcSock {
         let requested_remove_clone = self.requested_remove.clone();
         let socket_inotify = Inotify::init().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to initialize socket notifications: {:?}", e),
+                &format!("Failed to initialize socket notifications: {e:?}"),
                 NitroCliErrorEnum::InotifyError
             )
         })?;
@@ -93,7 +93,7 @@ impl EnclaveProcSock {
             )
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to add watch to inotify: {:?}", e),
+                    &format!("Failed to add watch to inotify: {e:?}"),
                     NitroCliErrorEnum::InotifyError
                 )
             })?;
@@ -139,7 +139,7 @@ impl EnclaveProcSock {
                 .join()
                 .map_err(|e| {
                     new_nitro_cli_failure!(
-                        &format!("Failed to join socket notification thread: {:?}", e),
+                        &format!("Failed to join socket notification thread: {e:?}"),
                         NitroCliErrorEnum::ThreadJoinFailure
                     )
                 })?;
@@ -173,7 +173,7 @@ fn socket_removal_listener(
             .read_events_blocking(&mut buffer)
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Socket removal listener error: {:?}", e),
+                    &format!("Socket removal listener error: {e:?}"),
                     NitroCliErrorEnum::InotifyError
                 )
                 .set_action("Run Enclave".to_string())
@@ -269,7 +269,7 @@ mod tests {
             UnixListener::bind(socket.get_path())
                 .map_err(|e| {
                     new_nitro_cli_failure!(
-                        &format!("Failed to bind to socket: {:?}", e),
+                        &format!("Failed to bind to socket: {e:?}"),
                         NitroCliErrorEnum::SocketError
                     )
                 })
@@ -306,7 +306,7 @@ mod tests {
             let _ = UnixListener::bind(socket.get_path())
                 .map_err(|e| {
                     new_nitro_cli_failure!(
-                        &format!("Failed to bind to socket: {:?}", e),
+                        &format!("Failed to bind to socket: {e:?}"),
                         NitroCliErrorEnum::SocketError
                     )
                 })

--- a/src/enclave_proc/utils.rs
+++ b/src/enclave_proc/utils.rs
@@ -97,7 +97,7 @@ pub fn generate_enclave_id(slot_id: u64) -> NitroCliResult<String> {
     if metadata(file_path).is_ok() {
         let mut file = File::open(file_path).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to open file: {:?}", e),
+                &format!("Failed to open file: {e:?}"),
                 NitroCliErrorEnum::FileOperationFailure
             )
             .add_info(vec![file_path, "Open"])
@@ -105,15 +105,15 @@ pub fn generate_enclave_id(slot_id: u64) -> NitroCliResult<String> {
         let mut contents = String::new();
         file.read_to_string(&mut contents).map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to read from file: {:?}", e),
+                &format!("Failed to read from file: {e:?}"),
                 NitroCliErrorEnum::FileOperationFailure
             )
             .add_info(vec![file_path, "Read"])
         })?;
         contents.retain(|c| !c.is_whitespace());
-        return Ok(format!("{}-enc{:x}", contents, slot_id));
+        return Ok(format!("{contents}-enc{slot_id:x}"));
     }
-    Ok(format!("i-0000000000000000-enc{:x}", slot_id))
+    Ok(format!("i-0000000000000000-enc{slot_id:x}"))
 }
 
 /// Obtain an enclave's slot ID from its full ID.
@@ -141,7 +141,7 @@ mod tests {
         if metadata(file_path).is_err() {
             assert!(enc_id
                 .unwrap()
-                .eq(&format!("i-0000000000000000-enc{:?}", slot_id)));
+                .eq(&format!("i-0000000000000000-enc{slot_id:?}")));
         } else {
             assert!(!enc_id
                 .unwrap()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ impl Console {
         )
         .map_err(|err| {
             new_nitro_cli_failure!(
-                &format!("Failed to create blocking console socket: {:?}", err),
+                &format!("Failed to create blocking console socket: {err:?}"),
                 NitroCliErrorEnum::SocketError
             )
         })?;
@@ -81,7 +81,7 @@ impl Console {
 
         connect(socket_fd, &sockaddr).map_err(|err| {
             new_nitro_cli_failure!(
-                &format!("Failed to connect to the console: {:?}", err),
+                &format!("Failed to connect to the console: {err:?}"),
                 NitroCliErrorEnum::EnclaveConsoleConnectionFailure
             )
         })?;
@@ -100,7 +100,7 @@ impl Console {
         )
         .map_err(|err| {
             new_nitro_cli_failure!(
-                &format!("Failed to create nonblocking console socket: {:?}", err),
+                &format!("Failed to create nonblocking console socket: {err:?}"),
                 NitroCliErrorEnum::SocketError
             )
         })?;
@@ -150,7 +150,7 @@ impl Console {
         // Initialize variables
         let epoll = Epoll::new().map_err(|e| {
             new_nitro_cli_failure!(
-                &format!("Failed to create epoll: {:?}", e),
+                &format!("Failed to create epoll: {e:?}"),
                 NitroCliErrorEnum::EpollError
             )
         })?;
@@ -164,7 +164,7 @@ impl Console {
             )
             .map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to add fd to epoll: {:?}", e),
+                    &format!("Failed to add fd to epoll: {e:?}"),
                     NitroCliErrorEnum::EpollError
                 )
             })?;
@@ -175,7 +175,7 @@ impl Console {
             // Create timerfd
             let mut timerfd = TimerFd::new().map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to initialize timerfd: {:?}", e),
+                    &format!("Failed to initialize timerfd: {e:?}"),
                     NitroCliErrorEnum::EpollError
                 )
             })?;
@@ -185,7 +185,7 @@ impl Console {
                 .reset(Duration::from_secs(disconnect_timeout), None)
                 .map_err(|e| {
                     new_nitro_cli_failure!(
-                        &format!("Failed to arm timerfd: {:?}", e),
+                        &format!("Failed to arm timerfd: {e:?}"),
                         NitroCliErrorEnum::EpollError
                     )
                 })?;
@@ -200,7 +200,7 @@ impl Console {
                 )
                 .map_err(|e| {
                     new_nitro_cli_failure!(
-                        &format!("Failed to add fd to epoll: {:?}", e),
+                        &format!("Failed to add fd to epoll: {e:?}"),
                         NitroCliErrorEnum::EpollError
                     )
                 })?;
@@ -213,7 +213,7 @@ impl Console {
             // Wait for kernel notification that one of the fds is available
             let num_events = epoll.wait(-1, &mut events).map_err(|e| {
                 new_nitro_cli_failure!(
-                    &format!("Failed to wait epoll: {:?}", e),
+                    &format!("Failed to wait epoll: {e:?}"),
                     NitroCliErrorEnum::EpollError
                 )
             })?;
@@ -227,7 +227,7 @@ impl Console {
                         let mut buffer = [0u8; BUFFER_SIZE];
                         let size = read(self.fd, &mut buffer).map_err(|e| {
                             new_nitro_cli_failure!(
-                                &format!("Failed to read data from the console: {:?}", e),
+                                &format!("Failed to read data from the console: {e:?}"),
                                 NitroCliErrorEnum::EnclaveConsoleReadError
                             )
                         })?;
@@ -241,8 +241,7 @@ impl Console {
                                 new_nitro_cli_failure!(
                                     &format!(
                                         "Failed to write data from the \
-                                        console to the given stream: {:?}",
-                                        e
+                                        console to the given stream: {e:?}"
                                     ),
                                     NitroCliErrorEnum::EnclaveConsoleWriteOutputError
                                 )
@@ -278,7 +277,7 @@ impl Console {
 
             let time_elapsed = sys_time.elapsed().map_err(|err| {
                 new_nitro_cli_failure!(
-                    &format!("System time moved backwards: {:?}", err),
+                    &format!("System time moved backwards: {err:?}"),
                     NitroCliErrorEnum::ClockSkewError
                 )
             })?;
@@ -308,10 +307,7 @@ fn vsock_set_connect_timeout(fd: RawFd, millis: i64) -> NitroCliResult<()> {
     match ret {
         0 => Ok(()),
         _ => Err(new_nitro_cli_failure!(
-            &format!(
-                "Failed to configure SO_VM_SOCKETS_CONNECT_TIMEOUT: {:?}",
-                ret
-            ),
+            &format!("Failed to configure SO_VM_SOCKETS_CONNECT_TIMEOUT: {ret:?}"),
             NitroCliErrorEnum::SocketConnectTimeoutError
         )),
     }

--- a/tests/test_dev_driver.rs
+++ b/tests/test_dev_driver.rs
@@ -62,7 +62,7 @@ impl NitroEnclavesDeviceDriver {
         Ok(NitroEnclavesDeviceDriver {
             file: File::open(NE_DEVICE_PATH).map_err(|e| {
                 NitroCliFailure::new()
-                    .add_subaction(format!("Could not open {}: {}", NE_DEVICE_PATH, e))
+                    .add_subaction(format!("Could not open {NE_DEVICE_PATH}: {e}"))
                     .set_error_code(NitroCliErrorEnum::FileOperationFailure)
                     .set_file_and_line(file!(), line!())
                     .add_info(vec![NE_DEVICE_PATH, "Open"])
@@ -79,10 +79,7 @@ impl NitroEnclavesDeviceDriver {
 
         if enc_fd < 0 {
             return Err(NitroCliFailure::new()
-                .add_subaction(format!(
-                    "Could not create an enclave descriptor: {}",
-                    enc_fd
-                ))
+                .add_subaction(format!("Could not create an enclave descriptor: {enc_fd}"))
                 .set_error_code(NitroCliErrorEnum::IoctlFailure)
                 .set_file_and_line(file!(), line!()));
         }
@@ -120,7 +117,7 @@ impl NitroEnclave {
         let rc = unsafe { libc::ioctl(self.enc_fd, NE_SET_USER_MEMORY_REGION as _, &mem_region) };
         if rc < 0 {
             return Err(NitroCliFailure::new()
-                .add_subaction(format!("Could not add memory region: {}", rc))
+                .add_subaction(format!("Could not add memory region: {rc}"))
                 .set_error_code(NitroCliErrorEnum::IoctlSetMemoryRegionFailure)
                 .set_file_and_line(file!(), line!()));
         }
@@ -133,7 +130,7 @@ impl NitroEnclave {
         let rc = unsafe { libc::ioctl(self.enc_fd, NE_ADD_VCPU as _, &mut actual_cpu_id) };
         if rc < 0 {
             return Err(NitroCliFailure::new()
-                .add_subaction(format!("Could not add vCPU: {}", rc))
+                .add_subaction(format!("Could not add vCPU: {rc}"))
                 .set_error_code(NitroCliErrorEnum::IoctlAddVcpuFailure)
                 .set_file_and_line(file!(), line!()));
         }
@@ -145,7 +142,7 @@ impl NitroEnclave {
         let rc = unsafe { libc::ioctl(self.enc_fd, NE_START_ENCLAVE as _, &start_info) };
         if rc < 0 {
             return Err(NitroCliFailure::new()
-                .add_subaction(format!("Could not start enclave: {}", rc))
+                .add_subaction(format!("Could not start enclave: {rc}"))
                 .set_error_code(NitroCliErrorEnum::IoctlEnclaveStartFailure)
                 .set_file_and_line(file!(), line!()));
         }
@@ -207,7 +204,7 @@ impl CheckDmesg {
             for word in checks.iter() {
                 if upper_line.contains(&word.to_uppercase()) {
                     return Err(NitroCliFailure::new()
-                        .add_subaction(format!("Dmesg line: {} contains: {}", line, word))
+                        .add_subaction(format!("Dmesg line: {line} contains: {word}"))
                         .set_error_code(NitroCliErrorEnum::IoctlFailure)
                         .set_file_and_line(file!(), line!()));
                 }
@@ -299,7 +296,7 @@ mod test_dev_driver {
         let result = enclave.add_mem_region(EnclaveMemoryRegion::new(
             0,
             region.mem_addr(),
-            u64::max_value() - (2 * 1024 * 1024) + 1,
+            u64::MAX - (2 * 1024 * 1024) + 1,
         ));
         assert!(result.is_err());
 
@@ -344,7 +341,7 @@ mod test_dev_driver {
         let cpu_info = CpuInfo::new().expect("Failed to obtain CpuInfo.");
 
         // Add an invalid cpu id.
-        let result = enclave.add_cpu(u32::max_value());
+        let result = enclave.add_cpu(u32::MAX);
         assert!(result.is_err());
 
         let mut candidates = cpu_info.get_cpu_candidates();
@@ -556,11 +553,11 @@ mod test_dev_driver {
         let result = enclave.start(enclave_start_info);
         assert!(result.is_err());
 
-        enclave_start_info.enclave_cid = u32::max_value() as u64;
+        enclave_start_info.enclave_cid = u32::MAX as u64;
         let result = enclave.start(enclave_start_info);
         assert!(result.is_err());
 
-        enclave_start_info.enclave_cid = u32::max_value() as u64 + 1234_u64;
+        enclave_start_info.enclave_cid = u32::MAX as u64 + 1234_u64;
         let result = enclave.start(enclave_start_info);
         assert!(result.is_err());
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -216,6 +216,7 @@ mod tests {
         let mut key_file = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(key_path)
             .unwrap();
         key_file
@@ -225,6 +226,7 @@ mod tests {
         let mut cert_file = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(cert_path)
             .unwrap();
         cert_file.write_all(&cert.to_pem().unwrap()).unwrap();
@@ -234,9 +236,9 @@ mod tests {
     fn build_enclaves_signed_simple_image() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
 
         setup_env();
@@ -323,9 +325,9 @@ mod tests {
     fn run_describe_terminate_signed_enclave_image() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
 
         setup_env();
@@ -369,9 +371,9 @@ mod tests {
     fn run_describe_terminate_separately_signed_enclave_image() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
 
         setup_env();
@@ -1044,9 +1046,9 @@ mod tests {
     fn build_describe_signed_simple_eif() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
 
         setup_env();
@@ -1086,9 +1088,9 @@ mod tests {
     fn build_sign_decribe_simple_eif() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
 
         setup_env();
@@ -1142,11 +1144,11 @@ mod tests {
     fn build_describe_signed_simple_eif_with_updated_signature() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
-        let cert_path2 = format!("{}/cert2.pem", dir_path);
-        let key_path2 = format!("{}/key2.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
+        let cert_path2 = format!("{dir_path}/cert2.pem");
+        let key_path2 = format!("{dir_path}/key2.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
         generate_signing_cert_and_key(&cert_path2, &key_path2);
 
@@ -1201,9 +1203,9 @@ mod tests {
     fn get_certificate_pcr() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
 
         setup_env();
@@ -1236,12 +1238,8 @@ mod tests {
         let pcr = get_file_pcr(cert_path, PcrType::SigningCertificate).unwrap();
 
         assert_eq!(
-            eif_info
-                .build_info
-                .measurements
-                .get(&"PCR8".to_string())
-                .unwrap(),
-            pcr.get(&"PCR8".to_string()).unwrap(),
+            eif_info.build_info.measurements.get("PCR8").unwrap(),
+            pcr.get("PCR8").unwrap(),
         );
     }
 
@@ -1249,9 +1247,9 @@ mod tests {
     fn get_certificate_pcr_after_separate_signing() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
 
         setup_env();
@@ -1291,12 +1289,8 @@ mod tests {
         let pcr = get_file_pcr(cert_path, PcrType::SigningCertificate).unwrap();
 
         assert_eq!(
-            eif_info
-                .build_info
-                .measurements
-                .get(&"PCR8".to_string())
-                .unwrap(),
-            pcr.get(&"PCR8".to_string()).unwrap(),
+            eif_info.build_info.measurements.get("PCR8").unwrap(),
+            pcr.get("PCR8").unwrap(),
         );
     }
 
@@ -1304,11 +1298,11 @@ mod tests {
     fn get_certificate_pcr_after_signature_update() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_str().unwrap();
-        let eif_path = format!("{}/test.eif", dir_path);
-        let cert_path = format!("{}/cert.pem", dir_path);
-        let key_path = format!("{}/key.pem", dir_path);
-        let cert_path2 = format!("{}/cert2.pem", dir_path);
-        let key_path2 = format!("{}/key2.pem", dir_path);
+        let eif_path = format!("{dir_path}/test.eif");
+        let cert_path = format!("{dir_path}/cert.pem");
+        let key_path = format!("{dir_path}/key.pem");
+        let cert_path2 = format!("{dir_path}/cert2.pem");
+        let key_path2 = format!("{dir_path}/key2.pem");
         generate_signing_cert_and_key(&cert_path, &key_path);
         generate_signing_cert_and_key(&cert_path2, &key_path2);
 
@@ -1349,12 +1343,8 @@ mod tests {
         let pcr = get_file_pcr(cert_path2, PcrType::SigningCertificate).unwrap();
 
         assert_eq!(
-            eif_info
-                .build_info
-                .measurements
-                .get(&"PCR8".to_string())
-                .unwrap(),
-            pcr.get(&"PCR8".to_string()).unwrap(),
+            eif_info.build_info.measurements.get("PCR8").unwrap(),
+            pcr.get("PCR8").unwrap(),
         );
     }
 
@@ -1366,7 +1356,7 @@ mod tests {
         fn build_describe_signed_simple_eif() {
             let dir = tempdir().unwrap();
             let dir_path = dir.path().to_str().unwrap();
-            let eif_path = format!("{}/test.eif", dir_path);
+            let eif_path = format!("{dir_path}/test.eif");
             let kms_key_arn = env::var("TEST_KMS_KEY_ARN").expect("Please set TEST_KMS_KEY_ARN");
             let kms_cert_path =
                 env::var("TEST_CERTIFICATE_PATH").expect("Please set TEST_CERTIFICATE_PATH");
@@ -1408,7 +1398,7 @@ mod tests {
         fn build_sign_decribe_simple_eif() {
             let dir = tempdir().unwrap();
             let dir_path = dir.path().to_str().unwrap();
-            let eif_path = format!("{}/test.eif", dir_path);
+            let eif_path = format!("{dir_path}/test.eif");
             let kms_key_arn = env::var("TEST_KMS_KEY_ARN").expect("Please set TEST_KMS_KEY_ARN");
             let kms_cert_path =
                 env::var("TEST_CERTIFICATE_PATH").expect("Please set TEST_CERTIFICATE_PATH");
@@ -1464,9 +1454,9 @@ mod tests {
         fn build_describe_signed_simple_eif_with_updated_signature_local_to_kms() {
             let dir = tempdir().unwrap();
             let dir_path = dir.path().to_str().unwrap();
-            let eif_path = format!("{}/test.eif", dir_path);
-            let local_cert_path = format!("{}/cert.pem", dir_path);
-            let local_key_path = format!("{}/key.pem", dir_path);
+            let eif_path = format!("{dir_path}/test.eif");
+            let local_cert_path = format!("{dir_path}/cert.pem");
+            let local_key_path = format!("{dir_path}/key.pem");
             generate_signing_cert_and_key(&local_cert_path, &local_key_path);
             let kms_key_arn = env::var("TEST_KMS_KEY_ARN").expect("Please set TEST_KMS_KEY_ARN");
             let kms_cert_path =
@@ -1523,9 +1513,9 @@ mod tests {
         fn build_describe_signed_simple_eif_with_updated_signature_kms_to_local() {
             let dir = tempdir().unwrap();
             let dir_path = dir.path().to_str().unwrap();
-            let eif_path = format!("{}/test.eif", dir_path);
-            let local_cert_path = format!("{}/cert.pem", dir_path);
-            let local_key_path = format!("{}/key.pem", dir_path);
+            let eif_path = format!("{dir_path}/test.eif");
+            let local_cert_path = format!("{dir_path}/cert.pem");
+            let local_key_path = format!("{dir_path}/key.pem");
             generate_signing_cert_and_key(&local_cert_path, &local_key_path);
             let kms_key_arn = env::var("TEST_KMS_KEY_ARN").expect("Please set TEST_KMS_KEY_ARN");
             let kms_cert_path =
@@ -1582,7 +1572,7 @@ mod tests {
         fn get_certificate_pcr() {
             let dir = tempdir().unwrap();
             let dir_path = dir.path().to_str().unwrap();
-            let eif_path = format!("{}/test.eif", dir_path);
+            let eif_path = format!("{dir_path}/test.eif");
             let kms_key_arn = env::var("TEST_KMS_KEY_ARN").expect("Please set TEST_KMS_KEY_ARN");
             let kms_cert_path =
                 env::var("TEST_CERTIFICATE_PATH").expect("Please set TEST_CERTIFICATE_PATH");
@@ -1617,12 +1607,8 @@ mod tests {
             let pcr = get_file_pcr(kms_cert_path, PcrType::SigningCertificate).unwrap();
 
             assert_eq!(
-                eif_info
-                    .build_info
-                    .measurements
-                    .get(&"PCR8".to_string())
-                    .unwrap(),
-                pcr.get(&"PCR8".to_string()).unwrap(),
+                eif_info.build_info.measurements.get("PCR8").unwrap(),
+                pcr.get("PCR8").unwrap(),
             );
         }
 
@@ -1630,7 +1616,7 @@ mod tests {
         fn get_certificate_pcr_after_separate_signing() {
             let dir = tempdir().unwrap();
             let dir_path = dir.path().to_str().unwrap();
-            let eif_path = format!("{}/test.eif", dir_path);
+            let eif_path = format!("{dir_path}/test.eif");
             let kms_key_arn = env::var("TEST_KMS_KEY_ARN").expect("Please set TEST_KMS_KEY_ARN");
             let kms_cert_path =
                 env::var("TEST_CERTIFICATE_PATH").expect("Please set TEST_CERTIFICATE_PATH");
@@ -1672,12 +1658,8 @@ mod tests {
             let pcr = get_file_pcr(kms_cert_path, PcrType::SigningCertificate).unwrap();
 
             assert_eq!(
-                eif_info
-                    .build_info
-                    .measurements
-                    .get(&"PCR8".to_string())
-                    .unwrap(),
-                pcr.get(&"PCR8".to_string()).unwrap(),
+                eif_info.build_info.measurements.get("PCR8").unwrap(),
+                pcr.get("PCR8").unwrap(),
             );
         }
 
@@ -1685,9 +1667,9 @@ mod tests {
         fn get_certificate_pcr_after_signature_update_local_to_kms() {
             let dir = tempdir().unwrap();
             let dir_path = dir.path().to_str().unwrap();
-            let eif_path = format!("{}/test.eif", dir_path);
-            let local_cert_path = format!("{}/cert.pem", dir_path);
-            let local_key_path = format!("{}/key.pem", dir_path);
+            let eif_path = format!("{dir_path}/test.eif");
+            let local_cert_path = format!("{dir_path}/cert.pem");
+            let local_key_path = format!("{dir_path}/key.pem");
             generate_signing_cert_and_key(&local_cert_path, &local_key_path);
             let kms_key_arn = env::var("TEST_KMS_KEY_ARN").expect("Please set TEST_KMS_KEY_ARN");
             let kms_cert_path =
@@ -1730,12 +1712,8 @@ mod tests {
             let pcr = get_file_pcr(kms_cert_path, PcrType::SigningCertificate).unwrap();
 
             assert_eq!(
-                eif_info
-                    .build_info
-                    .measurements
-                    .get(&"PCR8".to_string())
-                    .unwrap(),
-                pcr.get(&"PCR8".to_string()).unwrap(),
+                eif_info.build_info.measurements.get("PCR8").unwrap(),
+                pcr.get("PCR8").unwrap(),
             );
         }
 
@@ -1743,9 +1721,9 @@ mod tests {
         fn get_certificate_pcr_after_signature_update_kms_to_local() {
             let dir = tempdir().unwrap();
             let dir_path = dir.path().to_str().unwrap();
-            let eif_path = format!("{}/test.eif", dir_path);
-            let local_cert_path = format!("{}/cert.pem", dir_path);
-            let local_key_path = format!("{}/key.pem", dir_path);
+            let eif_path = format!("{dir_path}/test.eif");
+            let local_cert_path = format!("{dir_path}/cert.pem");
+            let local_key_path = format!("{dir_path}/key.pem");
             generate_signing_cert_and_key(&local_cert_path, &local_key_path);
             let kms_key_arn = env::var("TEST_KMS_KEY_ARN").expect("Please set TEST_KMS_KEY_ARN");
             let kms_cert_path =
@@ -1788,12 +1766,8 @@ mod tests {
             let pcr = get_file_pcr(local_cert_path, PcrType::SigningCertificate).unwrap();
 
             assert_eq!(
-                eif_info
-                    .build_info
-                    .measurements
-                    .get(&"PCR8".to_string())
-                    .unwrap(),
-                pcr.get(&"PCR8".to_string()).unwrap(),
+                eif_info.build_info.measurements.get("PCR8").unwrap(),
+                pcr.get("PCR8").unwrap(),
             );
         }
     }

--- a/vsock_proxy/src/dns.rs
+++ b/vsock_proxy/src/dns.rs
@@ -103,7 +103,7 @@ pub fn resolve_single(addr: &str, ip_addr_type: IpAddrType) -> VsockProxyResult<
     rresults
         .first()
         .cloned()
-        .ok_or_else(|| format!("Unable to resolve the DNS name: {}", addr))
+        .ok_or_else(|| format!("Unable to resolve the DNS name: {addr}"))
 }
 
 #[cfg(test)]
@@ -116,10 +116,10 @@ mod tests {
 
     static TEST_INIT: Once = Once::new();
 
-    static mut INVALID_TEST_DOMAIN: &'static str = "invalid-domain";
-    static mut IPV4_ONLY_TEST_DOMAIN: &'static str = "v4.ipv6test.app";
-    static mut IPV6_ONLY_TEST_DOMAIN: &'static str = "v6.ipv6test.app";
-    static mut DUAL_IP_TEST_DOMAIN: &'static str = "ipv6test.app";
+    static mut INVALID_TEST_DOMAIN: &str = "invalid-domain";
+    static mut IPV4_ONLY_TEST_DOMAIN: &str = "v4.ipv6test.app";
+    static mut IPV6_ONLY_TEST_DOMAIN: &str = "v6.ipv6test.app";
+    static mut DUAL_IP_TEST_DOMAIN: &str = "ipv6test.app";
 
     #[test]
     #[ctor]

--- a/vsock_proxy/src/main.rs
+++ b/vsock_proxy/src/main.rs
@@ -120,15 +120,15 @@ fn main() -> VsockProxyResult<()> {
         num_workers,
         ip_addr_type,
     )
-    .map_err(|err| format!("Could not create proxy: {}", err))?;
+    .map_err(|err| format!("Could not create proxy: {err}"))?;
 
     let listener = proxy
         .sock_listen()
-        .map_err(|err| format!("Could not listen for connections: {}", err))?;
+        .map_err(|err| format!("Could not listen for connections: {err}"))?;
     info!("Proxy is now in listening state");
     loop {
         proxy
             .sock_accept(&listener)
-            .map_err(|err| format!("Could not accept connection: {}", err))?;
+            .map_err(|err| format!("Could not accept connection: {err}"))?;
     }
 }

--- a/vsock_proxy/src/proxy.rs
+++ b/vsock_proxy/src/proxy.rs
@@ -124,7 +124,7 @@ impl Proxy {
     pub fn sock_listen(&self) -> VsockProxyResult<VsockListener> {
         let sockaddr = VsockAddr::new(VSOCK_PROXY_CID, self.local_port);
         let listener = VsockListener::bind(&sockaddr)
-            .map_err(|_| format!("Could not bind to {:?}", sockaddr))?;
+            .map_err(|_| format!("Could not bind to {sockaddr:?}"))?;
         info!("Bound to {:?}", sockaddr);
 
         Ok(listener)
@@ -168,7 +168,7 @@ impl Proxy {
         self.pool.execute(move || {
             let mut server = match sock_type {
                 SockType::Stream => TcpStream::connect(sockaddr)
-                    .map_err(|_| format!("Could not connect to {:?}", sockaddr)),
+                    .map_err(|_| format!("Could not connect to {sockaddr:?}")),
                 _ => Err("Socket type not implemented".to_string()),
             }
             .expect("Could not create connection");

--- a/vsock_proxy/tests/connection_test.rs
+++ b/vsock_proxy/tests/connection_test.rs
@@ -64,7 +64,7 @@ fn test_tcp_connection() {
     let listener = ret.expect("proxy listen");
     let proxy_handle = thread::spawn(move || {
         tx.send(true).expect("proxy send event");
-        let _ret = proxy.sock_accept(&listener).expect("proxy accept");
+        proxy.sock_accept(&listener).expect("proxy accept");
     });
 
     let _ret = rx.recv().expect("main recv event");


### PR DESCRIPTION
This PR updates the build scripts to fix the compilation errors.

Changes:
* Updates the Makefile to use proper CC target (musl-gcc), this resolves linker errors
* Fixes Clippy errors from Rust 1.87.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.