### PR TITLE
Release v1.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "nitro-cli"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "aws-nitro-enclaves-image-format",
  "bindgen",
@@ -3071,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitro-cli"
-version = "1.4.4"
+version = "1.4.5"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -20,7 +20,7 @@
 
 Summary:    AWS Nitro Enclaves tools for managing enclaves
 Name:       aws-nitro-enclaves-cli
-Version:    1.4.4
+Version:    1.4.5
 Release:    0%{?dist}
 
 License:    Apache 2.0
@@ -195,6 +195,14 @@ fi
 %{ne_include_dir}/*
 
 %changelog
+* Fri May 01 2026 Mushahid Hussain <hmushi@amazon.co.uk> - 1.4.5-0
+- Bump tar crate to 0.4.45 to address CVE-2026-33055 and CVE-2026-33056
+- Fix Clippy warnings for Rust 1.92
+- Bump Rust version to 1.92
+- scripts/bump-rust-version.sh: Switch to two-part versioning
+- tools/Dockerfile: Build openssl silently
+- enclave_build: Always print errors when handling builder streams
+
 * Mon Jan 12 2026 Leonard Foerster <foersleo@amazon.com> - 1.4.4-0"
 - vsock-proxy: configs: Add missing regions
 - vsock-proxy: configs: Reorder regions aligned with kms docs

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -1727,7 +1727,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.4.4</a></li>
+                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.4.5</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -3811,8 +3811,6 @@ limitations under the License.
                     <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.29</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.93</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.38</a></li>
-                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.18</a></li>
-                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.24</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.217</a></li>
                     <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.15</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.217</a></li>
@@ -3825,7 +3823,6 @@ limitations under the License.
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.12</a></li>
                     <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.14</a></li>
-                    <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5758,7 +5755,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.13.2</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.8</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.0</a></li>
-                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.43</a></li>
+                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.45</a></li>
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.19.1</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url 2.5.4</a></li>
                     <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.12.0</a></li>
@@ -7247,6 +7244,9 @@ limitations under the License.
                     <li><a href=" https://github.com/starkat99/half-rs ">half 1.8.3</a></li>
                     <li><a href=" https://github.com/starkat99/half-rs ">half 2.4.1</a></li>
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
+                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.18</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.24</a></li>
+                    <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                 </ul>
                 <pre class="license-text">Apache License
 Version 2.0, January 2004
@@ -7519,6 +7519,36 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.101.7</a></li>
+                </ul>
+                <pre class="license-text">// Copyright 2021 Brian Smith.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHORS DISCLAIM ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#[test]
+fn cert_without_extensions_test() {
+    // Check the certificate is valid with
+    // &#x60;openssl x509 -in cert_without_extensions.der -inform DER -text -noout&#x60;
+    const CERT_WITHOUT_EXTENSIONS_DER: &amp;[u8] &#x3D; include_bytes!(&quot;cert_without_extensions.der&quot;);
+
+    assert!(webpki::EndEntityCert::try_from(CERT_WITHOUT_EXTENSIONS_DER).is_ok());
+}
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/hannobraun/inotify-sys ">inotify-sys 0.1.5</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) Hanno Braun and contributors
@@ -7601,10 +7631,35 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.3</a></li>
+                </ul>
+                <pre class="license-text">Except as otherwise noted, this project is licensed under the following
+(ISC-style) terms:
+
+Copyright 2015 Brian Smith.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHORS DISCLAIM ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+The files under third-party/chromium are licensed as described in
+third-party/chromium/LICENSE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.13.1</a></li>
                     <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.29.0</a></li>
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.101.7</a></li>
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.3</a></li>
                 </ul>
                 <pre class="license-text">ISC License:
 

--- a/enclave_build/Cargo.toml
+++ b/enclave_build/Cargo.toml
@@ -22,5 +22,5 @@ sha2 = "0.9.5"
 futures = "0.3.28"
 
 aws-nitro-enclaves-image-format = "0.5"
-tar = "0.4.40"
+tar = "0.4.45"
 flate2 = "1.1.1"

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-da158a79f419a3b41f774c6abeffb68751f3b886  nitro-cli-dependencies.tar.gz
+2f692712602fc0f74d0294adedda832bafb67b53  nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
## Summary

Release v1.4.5. Primary change is bumping the `tar` crate from `0.4.43` to `0.4.45` in `enclave_build/` to address two vulnerabilities in the bundled tar archive library:

- **CVE-2026-33055** / [RUSTSEC-2026-0068](https://rustsec.org/advisories/RUSTSEC-2026-0068.html) — conditional PAX size header handling inconsistent with other tar parsers.
- **CVE-2026-33056** / [RUSTSEC-2026-0067](https://rustsec.org/advisories/RUSTSEC-2026-0067.html) — symlink-based `chmod` escape outside the extraction root in `unpack_dir()`.

Both are fixed in `tar` 0.4.45.

The release also rolls up the five commits that have landed on `main` since v1.4.4:
- Fix Clippy warnings for Rust 1.92
- Bump Rust version to 1.92
- `scripts/bump-rust-version.sh`: switch to two-part versioning
- `tools/Dockerfile`: build openssl silently
- `enclave_build`: always print errors when handling builder streams

## Files changed

- `enclave_build/Cargo.toml` — `tar = "0.4.40"` → `tar = "0.4.45"`
- `Cargo.toml` — `version = "1.4.4"` → `version = "1.4.5"`
- `Cargo.lock` — regenerated (minimal diff: only `tar` + `nitro-cli` version bumps, schema v3 preserved)
- `SPECS/aws-nitro-enclaves-cli.spec` — `Version: 1.4.5`, new `1.4.5-0` changelog entry
- `sources` — regenerated via `make update-crates-dependencies` (new vendored tarball SHA1)
- `THIRD_PARTY_LICENSES_RUST_CRATES.html` — regenerated via `make update-third-party-licenses-rust-crates-html` (reflects `tar 0.4.45`)

## Verification

- `cargo build --workspace --release` — clean.
- `cargo test --workspace --lib --bins -- --test-threads=1` — 72/72 pass.
- `cargo audit` — both `RUSTSEC-2026-0067` and `RUSTSEC-2026-0068` no longer appear; diff against `main` confirms exactly those two advisories are removed and no new ones are introduced.
- Vendored `crates-dependencies/tar/Cargo.toml` confirms `version = "0.4.45"`.
