### PR TITLE
Fix clippy::unnecessary_sort_by lint from Rust 1.95

### DIFF
--- a/src/enclave_proc/resource_manager.rs
+++ b/src/enclave_proc/resource_manager.rs
@@ -407,7 +407,7 @@ impl ResourceAllocator {
         // At this point, we may have allocated more than we need, so we release all
         // regions we no longer need, starting with the smallest ones.
         self.mem_regions
-            .sort_by(|reg1, reg2| reg2.mem_size.cmp(&reg1.mem_size));
+            .sort_by_key(|region| std::cmp::Reverse(region.mem_size));
 
         needed_mem = self.requested_mem as i64;
         for region in self.mem_regions.iter() {


### PR DESCRIPTION
## Summary

Fix a clippy regression in `src/enclave_proc/resource_manager.rs` that is currently breaking the `Clippy` CI job on every PR.

The `clippy::unnecessary_sort_by` lint flags the descending-sort closure in `ResourceAllocator::split` and suggests rewriting it with `sort_by_key` + `std::cmp::Reverse`. This lint became applicable here as of **Rust 1.95 (stable, 2026-04-14)**; the job uses `dtolnay/rust-toolchain@stable` and fails because `resource_manager.rs` carries `#![deny(warnings)]`.

Before:

```rust
self.mem_regions
    .sort_by(|reg1, reg2| reg2.mem_size.cmp(&reg1.mem_size));
```

After:

```rust
self.mem_regions
    .sort_by_key(|region| std::cmp::Reverse(region.mem_size));
```

## Behavior

No functional change. Both `Vec::sort_by` and `Vec::sort_by_key` are stable sorts, and `std::cmp::Reverse(u64)` gives the same ordering as the previous comparator. Equal-sized regions keep their relative order.

## Verification

- `cargo clippy --all` with `RUSTFLAGS="-Dwarnings"` — clean (previously produced `error: consider using sort_by_key` → `error: could not compile nitro-cli`).
- `cargo fmt --all -- --check` — clean.
- `cargo test --workspace --lib --bins -- --test-threads=1` — 72/72 pass.

Lint reference: https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#unnecessary_sort_by
