### PR TITLE
fix(vsock-proxy): skip DNS resolution for IP addresses, reject bare numeric remote_addr

### DIFF
--- a/vsock_proxy/src/dns.rs
+++ b/vsock_proxy/src/dns.rs
@@ -47,6 +47,11 @@ impl DnsResolutionInfo {
 
 /// Resolve a DNS name (IDNA format) into multiple IP addresses (v4 or v6)
 pub fn resolve(addr: &str, ip_addr_type: IpAddrType) -> VsockProxyResult<Vec<DnsResolutionInfo>> {
+    // If addr is already a valid IP address, skip DNS resolution entirely.
+    if let Ok(ip) = addr.parse::<IpAddr>() {
+        return Ok(vec![DnsResolutionInfo::new(ip, Duration::seconds(0))]);
+    }
+
     // IDNA parsing
     let addr = domain_to_ascii(addr).map_err(|_| "Could not parse domain name")?;
 
@@ -186,5 +191,29 @@ mod tests {
         let rresult = resolve_single(domain, IpAddrType::IPAddrMixed).unwrap();
         assert!(rresult.ip_addr().is_ipv4());
         assert!(rresult.ttl != Duration::seconds(0));
+    }
+
+    #[test]
+    fn test_resolve_ipv4_address_skips_dns() {
+        let rresults = resolve("127.0.0.1", IpAddrType::IPAddrMixed).unwrap();
+        assert_eq!(rresults.len(), 1);
+        assert_eq!(
+            rresults[0].ip_addr(),
+            "127.0.0.1".parse::<IpAddr>().unwrap()
+        );
+        assert_eq!(rresults[0].ttl(), Duration::seconds(0));
+    }
+
+    #[test]
+    fn test_resolve_ipv6_address_skips_dns() {
+        let rresults = resolve("::1", IpAddrType::IPAddrMixed).unwrap();
+        assert_eq!(rresults.len(), 1);
+        assert_eq!(rresults[0].ip_addr(), "::1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn test_resolve_single_with_ip_address() {
+        let rresult = resolve_single("10.0.0.1", IpAddrType::IPAddrV4Only).unwrap();
+        assert_eq!(rresult.ip_addr(), "10.0.0.1".parse::<IpAddr>().unwrap());
     }
 }

--- a/vsock_proxy/src/main.rs
+++ b/vsock_proxy/src/main.rs
@@ -110,6 +110,18 @@ fn main() -> VsockProxyResult<()> {
     info!("Checking allowlist configuration");
     let config_file = matches.get_one::<String>("config_file").map(String::as_str);
     let remote_host = remote_addr.to_string();
+
+    // Reject bare numeric strings early with a helpful message.
+    // A bare number like "19" is likely a vsock CID passed by mistake.
+    if remote_addr.parse::<u32>().is_ok() {
+        return Err(format!(
+            "'{}' is not a valid hostname or IP address. \
+             Note: remote_addr is the TCP destination to forward traffic to, \
+             not the enclave CID.",
+            remote_addr
+        ));
+    }
+
     check_allowlist(&remote_host, remote_port, config_file, ip_addr_type)
         .map_err(|err| format!("Error at checking the allowlist: {err}"))?;
 


### PR DESCRIPTION
*Issue #, if available:*
#716

*Description of changes:*
When `remote_addr` is a valid IP address (for ex, `127.0.0.1`), `dns::resolve()` now returns it directly instead of passing it to the system resolver. This prevents unnecessary DNS failures when users pass IP addresses as the remote destination

Additionally, if `remote_addr` is a bare numeric string (for ex, `19`), the proxy now exits early with an error message indicating that `remote_addr` is the TCP destination, not the enclave CID. This addresses the confusing "DNS lookup failed" error reported in #716, where the system resolver appends the VPC search domain (producing `19.ec2.internal`) and NXDOMAINs

**Testing:**
- `vsock-proxy 8080 19 8080` now prints a clear error
- `vsock-proxy 8080 127.0.0.1 443` passes the numeric guard

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
