### PR TITLE
Prepare release 1.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "nitro-cli"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "aws-nitro-enclaves-image-format",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nitro-cli"
-version = "1.4.4"
+version = "1.4.5"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -20,7 +20,7 @@
 
 Summary:    AWS Nitro Enclaves tools for managing enclaves
 Name:       aws-nitro-enclaves-cli
-Version:    1.4.4
+Version:    1.4.5
 Release:    0%{?dist}
 
 License:    Apache 2.0
@@ -195,6 +195,16 @@ fi
 %{ne_include_dir}/*
 
 %changelog
+* Tue Jun 02 2026 Jasper Wise <jaspwise@amazon.co.uk> - 1.4.5-0
+- Update tar from 0.4.43 to 0.4.46
+- Update openssl from 0.10.72 to 0.10.80
+- Fix clippy::unnecessary_sort_by lint from Rust 1.95
+- Fix Clippy warnings for Rust 1.92
+- Bump Rust version to 1.92
+- scripts/bump-rust-version.sh: Switch to two-part versioning
+- tools/Dockerfile: Build openssl silently
+- enclave_build: Always print errors when handling builder streams
+
 * Mon Jan 12 2026 Leonard Foerster <foersleo@amazon.com> - 1.4.4-0"
 - vsock-proxy: configs: Add missing regions
 - vsock-proxy: configs: Reorder regions aligned with kms docs

--- a/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -1727,7 +1727,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.4.4</a></li>
+                    <li><a href=" https://crates.io/crates/nitro-cli ">nitro-cli 1.4.5</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -3174,7 +3174,7 @@ Software.
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
                     <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.1</a></li>
                     <li><a href=" https://crates.io/crates/openssl-macros ">openssl-macros 0.1.1</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl 0.10.72</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl 0.10.80</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -5758,7 +5758,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.13.2</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.8</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.0</a></li>
-                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.43</a></li>
+                    <li><a href=" https://github.com/composefs/tar-rs ">tar 0.4.46</a></li>
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.19.1</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url 2.5.4</a></li>
                     <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.12.0</a></li>
@@ -7327,7 +7327,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl 0.10.72</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl 0.10.80</a></li>
                 </ul>
                 <pre class="license-text">Copyright 2011-2017 Google Inc.
           2013 Jack Lloyd
@@ -7601,10 +7601,36 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.13.1</a></li>
-                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.29.0</a></li>
                     <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.101.7</a></li>
                     <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.3</a></li>
+                </ul>
+                <pre class="license-text">Except as otherwise noted, this project is licensed under the following
+(ISC-style) terms:
+
+Copyright 2015 Brian Smith.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHORS DISCLAIM ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+The files under third-party/chromium are licensed as described in
+third-party/chromium/LICENSE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.13.1</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.29.0</a></li>
                 </ul>
                 <pre class="license-text">ISC License:
 
@@ -7620,7 +7646,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl-sys 0.9.107</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl-sys 0.9.116</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Alex Crichton
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-da158a79f419a3b41f774c6abeffb68751f3b886  nitro-cli-dependencies.tar.gz
+5e72d22dd2801a0c900124c0d34a414219e6f36d  nitro-cli-dependencies.tar.gz


### PR DESCRIPTION
Update changelog and dependency licenses for release 1.4.5

*Description of changes:*
- Prepare release 1.4.5
- Update tar from 0.4.43 to 0.4.46
- Update openssl from 0.10.72 to 0.10.80
- Fix clippy::unnecessary_sort_by lint from Rust 1.95
- Fix Clippy warnings for Rust 1.92
- Bump Rust version to 1.92
- scripts/bump-rust-version.sh: Switch to two-part versioning
- tools/Dockerfile: Build openssl silently
- enclave_build: Always print errors when handling builder streams

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
