### PR TITLE
Fix file descriptor leaks in enclave_proc_command_send_all

### DIFF
--- a/src/enclave_proc_comm.rs
+++ b/src/enclave_proc_comm.rs
@@ -148,12 +148,46 @@ where
 {
     // Open a connection to each valid socket.
     let mut replies: Vec<UnixStream> = vec![];
-    let epoll_fd = epoll::epoll_create().map_err(|e| {
-        new_nitro_cli_failure!(
-            &format!("Failed to create epoll: {e:?}"),
-            NitroCliErrorEnum::EpollError
-        )
-    })?;
+
+    // RAII guard that owns the epoll instance and every per-connection
+    // descriptor that has been detached from its `UnixStream` via
+    // `into_raw_fd` but not yet handed back to the caller. It closes all of
+    // those descriptors on every return path, including the early `?`
+    // propagations below and the `epoll_wait` timeout branch.
+    //
+    // This is required because `nix::sys::epoll::epoll_create` returns a bare
+    // `RawFd` that is not closed when it goes out of scope, and the connection
+    // descriptors are detached from their `UnixStream`s by `into_raw_fd`.
+    // Without this guard the function leaks one epoll descriptor on every call
+    // (plus one connection descriptor for every socket that does not reply
+    // before `epoll_wait` times out), which eventually exhausts the process
+    // file-descriptor limit (EMFILE) for any long-running caller that polls
+    // enclave state periodically.
+    struct EpollConns {
+        epoll_fd: RawFd,
+        pending_fds: std::collections::HashSet<RawFd>,
+    }
+
+    impl Drop for EpollConns {
+        fn drop(&mut self) {
+            for fd in self.pending_fds.drain() {
+                let _ = close(fd);
+            }
+            let _ = close(self.epoll_fd);
+        }
+    }
+
+    let mut conns = EpollConns {
+        epoll_fd: epoll::epoll_create().map_err(|e| {
+            new_nitro_cli_failure!(
+                &format!("Failed to create epoll: {e:?}"),
+                NitroCliErrorEnum::EpollError
+            )
+        })?,
+        pending_fds: std::collections::HashSet::new(),
+    };
+    let epoll_fd = conns.epoll_fd;
+
     let comms: Vec<NitroCliResult<()>> = enclave_proc_connect_to_all()
         .map_err(|e| {
             e.add_subaction("Failed to send command to all enclave processes".to_string())
@@ -164,6 +198,10 @@ where
             enclave_proc_command_send_single(cmd, args, socket.borrow_mut())?;
 
             let raw_fd = socket.into_raw_fd();
+            // Track the detached descriptor so it is still closed if it never
+            // gets returned by `epoll_wait` (e.g. on a timeout) or if the
+            // registration below fails.
+            conns.pending_fds.insert(raw_fd);
             let mut process_evt = EpollEvent::new(EpollFlags::EPOLLIN, raw_fd as u64);
 
             // Add each valid connection to epoll.
@@ -210,13 +248,19 @@ where
         // We will handle this reply, irrespective of its status (successful or failed).
         num_replies_expected -= 1;
 
-        // Check if a time-out has occurred.
+        // Check if a time-out has occurred. Any descriptor that did not reply
+        // stays tracked in `conns.pending_fds` and is closed when `conns` is
+        // dropped, instead of being leaked.
         if num_events == 0 {
             continue;
         }
 
         let input_stream_raw_fd = events[0].data() as RawFd;
         let mut input_stream = unsafe { UnixStream::from_raw_fd(input_stream_raw_fd) };
+        // Ownership of this descriptor now belongs to `input_stream` (and, if
+        // confirmed, to the `UnixStream` returned to the caller), so stop
+        // tracking it here to avoid a double close.
+        conns.pending_fds.remove(&input_stream_raw_fd);
 
         // Handle the reply we received.
         if let Ok(reply) = read_u64_le(&mut input_stream) {


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

## Summary

`enclave_proc_command_send_all()` in `src/enclave_proc_comm.rs` leaks file descriptors on every invocation. For a one-shot CLI command this is harmless, but any long-running process that links this crate and calls the function on an interval (for example, a service that periodically issues a `Describe` to check enclave state) steadily accumulates descriptors until it reaches its `RLIMIT_NOFILE`. After that, every subsequent socket/accept syscall in the process fails with `EMFILE` ("No file descriptors available").

## Root cause

There are two distinct leaks in the function:

1. **epoll instance (leaks on every call).** The function obtains an epoll fd via `nix::sys::epoll::epoll_create()` and never closes it:

   ```rust
   let epoll_fd = epoll::epoll_create().map_err(...)?;
   ```

   With `nix` 0.26, `epoll_create` returns a bare `RawFd` that is **not** closed when it goes out of scope, so exactly one descriptor is leaked per call regardless of outcome.

2. **Connection sockets (leaks on the `epoll_wait` timeout path).** Each connection is detached from its `UnixStream` with `into_raw_fd()` and registered with epoll. A descriptor is only turned back into a `UnixStream` (and thus eventually closed) when `epoll_wait` reports an event for it. When a peer does not reply within `ENCLAVE_PROC_WAIT_TIMEOUT_MSEC`, the loop hits `if num_events == 0 { continue; }` and that connection's fd is never reclaimed, never removed from epoll, and never closed — one leaked descriptor per unanswered connection. The early `?` returns inside the loop have the same problem.

The first leak is deterministic and constant-rate, so a periodic caller exhausts its fd table after a fixed, predictable runtime.

## Fix

Introduce a small RAII guard, local to the function, that owns the epoll fd and the set of detached connection fds, and closes all of them in `Drop`. This guarantees cleanup on **every** return path — the normal return, the early `?` propagations during setup and in the wait loop, and the `epoll_wait` timeout branch. Descriptors that are successfully reclaimed into `UnixStream`s are released from the guard first, so there is no double close.

The change is confined to `enclave_proc_command_send_all`; the function's signature and observable behaviour are unchanged.

## Testing

- `cargo check` passes (the crate sets `#![deny(warnings)]`, so the build also confirms the change is warning-free).
- Reviewed all exit paths to confirm each fd is closed exactly once: reclaimed-and-returned sockets are closed by the caller; reclaimed-but-unconfirmed sockets are closed when their `UnixStream` drops; timed-out and registration-failed sockets plus the epoll fd are closed by the guard.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.