### PR TITLE
Fail hard on sign_info setup issues

### DIFF
--- a/enclave_build/src/lib.rs
+++ b/enclave_build/src/lib.rs
@@ -99,14 +99,11 @@ impl<'a> Docker2Eif<'a> {
         }
 
         let sign_info = match (private_key, certificate_path) {
-            (Some(key), Some(cert)) => SignKeyData::new(key, Path::new(&cert)).map_or_else(
-                |e| {
-                    eprintln!("Could not read signing info: {e:?}");
-                    None
-                },
-                Some,
+            (Some(key), Some(cert)) => Some(
+                SignKeyData::new(key, Path::new(&cert)).map_err(Docker2EifError::SignImageError)?,
             ),
-            _ => None,
+            (None, None) => None,
+            _ => return Err(Docker2EifError::SignArgsError),
         };
 
         Ok(Docker2Eif {


### PR DESCRIPTION
*Description of changes:*

This commit introduces a behavioural change to the error handling, to make the EIF building fail hard whenever it fails to prepare the signing info, and have it exit with a non-zero exit code.

Also fail hard if only providing one of the private key and certificate, since both are required to sign the EIF.

*Issue #, if available:*
#756 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
